### PR TITLE
feat: support global install with cli name

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "url": "git+https://github.com/eslint/config-inspector.git"
   },
   "bugs": "https://github.com/eslint/config-inspector/issues",
-  "bin": "./bin.mjs",
+  "bin": {
+    "@eslint/config-inspector": "./bin.mjs",
+    "eslint-config-inspector": "./bin.mjs"
+  },
   "files": [
     "*.mjs",
     "dist"


### PR DESCRIPTION
Since we moved to the scoped package name, we can't directly execute it with `npx`. This PR adds an alias to have `eslint-config-inspector` registered as the cli command as well