### PR TITLE
chore: update wording

### DIFF
--- a/components/RuleItem.vue
+++ b/components/RuleItem.vue
@@ -73,10 +73,10 @@ function capitalize(str?: string) {
             <NuxtLink
               action-button
               :to="rule.docs?.url" target="_blank" rel="noopener noreferrer"
-              title="Documentations"
+              title="Docs"
             >
               <div i-ph-book-duotone />
-              Documentations
+              Docs
             </NuxtLink>
             <button
               action-button


### PR DESCRIPTION
Hi,

Thanks to antfu for this project, great to see it's now an officially endorsed effort.

A very small change here: I believe `Documentations` isn't general vernacular.

Before:

![CleanShot 2024-03-30 at 7  33 11@2x](https://github.com/eslint/config-inspector/assets/654103/8d9487be-a30d-4a16-a9f9-7c804459b451)

After:
![CleanShot 2024-03-30 at 7  39 17@2x](https://github.com/eslint/config-inspector/assets/654103/a3f30126-a1d9-407c-a3d8-7b3b388c50b6)

