### PR TITLE
feat: improve how configures are resolved

### DIFF
--- a/app/components/ConfigItem.vue
+++ b/app/components/ConfigItem.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed, defineModel } from 'vue'
-import { isGridView } from '~/composables/state'
+import { computed, defineModel, ref, watchEffect } from 'vue'
+import { filtersRules, isGridView } from '~/composables/state'
 import { stringifyUnquoted } from '~/composables/strings'
-import { filtersRules } from '~/composables/state'
 import { useRouter } from '#app/composables/router'
 import type { FiltersConfigsPage, FlatESLintConfigItem } from '~~/types'
 
@@ -12,7 +11,6 @@ const props = defineProps<{
   filters?: FiltersConfigsPage
   active?: boolean
 }>()
-
 
 const emit = defineEmits<{
   badgeClick: [string]

--- a/app/server/api/payload.json.ts
+++ b/app/server/api/payload.json.ts
@@ -1,7 +1,10 @@
+import process from 'node:process'
 import { createWsServer } from '~~/src/ws'
 
 export default lazyEventHandler(async () => {
-  const ws = await createWsServer()
+  const ws = await createWsServer({
+    cwd: process.cwd(),
+  })
 
   return defineEventHandler(async () => {
     return await ws.getData()

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "connect": "^3.7.0",
     "esbuild": "^0.20.2",
     "fast-glob": "^3.3.2",
+    "find-up": "^7.0.0",
     "get-port-please": "^3.1.2",
     "minimatch": "^9.0.4",
     "open": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   fast-glob:
     specifier: ^3.3.2
     version: 3.3.2
+  find-up:
+    specifier: ^7.0.0
+    version: 7.0.0
   get-port-please:
     specifier: ^3.1.2
     version: 3.1.2
@@ -5308,7 +5311,6 @@ packages:
       locate-path: 7.2.0
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
-    dev: true
 
   /flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -6274,7 +6276,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       p-locate: 6.0.0
-    dev: true
 
   /lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -7256,7 +7257,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
-    dev: true
 
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -7277,7 +7277,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       p-limit: 4.0.0
-    dev: true
 
   /p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
@@ -7388,7 +7387,6 @@ packages:
   /path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -8825,7 +8823,6 @@ packages:
   /unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
-    dev: true
 
   /unimport@3.7.1(rollup@3.29.4):
     resolution: {integrity: sha512-V9HpXYfsZye5bPPYUgs0Otn3ODS1mDUciaBlXljI4C2fTwfFpvFZRywmlOu943puN9sncxROMZhsZCjNXEpzEQ==}
@@ -9621,7 +9618,6 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /zhead@2.2.4:
     resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ const cli = cac()
 cli
   .command('build', 'Build inspector with current config file for static hosting')
   .option('--config <configFile>', 'Config file path')
-  .option('--root <rootPath>', 'Root directory to inspect files. Default to directory of config file if not provided')
+  .option('--basePath <basePath>', 'Base directory for globs to resolve. Default to directory of config file if not provided')
   .option('--out-dir <dir>', 'Output directory', { default: '.eslint-config-inspector' })
   .action(async (options) => {
     console.log('Building static ESLint config inspector...')
@@ -27,7 +27,7 @@ cli
     const configs = await readConfig({
       cwd,
       userConfigPath: options.config,
-      userRootPath: options.root,
+      userBasePath: options.basePath,
     })
 
     if (existsSync(outDir))
@@ -47,7 +47,7 @@ cli
 cli
   .command('', 'Start dev inspector')
   .option('--config <configFile>', 'Config file path')
-  .option('--root <rootPath>', 'Root directory to inspect files. Default to directory of config file if not provided')
+  .option('--basePath <basePath>', 'Base directory for globs to resolve. Default to directory of config file if not provided')
   .option('--host <host>', 'Host', { default: process.env.HOST || '127.0.0.1' })
   .option('--port <port>', 'Port', { default: process.env.PORT || 7777 })
   .option('--open', 'Open browser', { default: true })
@@ -64,7 +64,7 @@ cli
     const server = await createHostServer({
       cwd,
       userConfigPath: options.config,
-      userRootPath: options.root,
+      userBasePath: options.basePath,
     })
 
     server.listen(port, host)

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from 'node:path'
+import process from 'node:process'
 import { bundleRequire } from 'bundle-require'
 import type { Linter } from 'eslint'
 import fg from 'fast-glob'
@@ -18,6 +19,11 @@ export interface ReadConfigOptions {
   cwd: string
   userConfigPath?: string
   userRootPath?: string
+  /**
+   * Change current working directory to rootPath
+   * @default true
+   */
+  chdir?: boolean
 }
 
 export async function readConfig(
@@ -25,6 +31,7 @@ export async function readConfig(
     cwd,
     userConfigPath,
     userRootPath,
+    chdir = true,
   }: ReadConfigOptions,
 ): Promise<{ payload: Payload, dependencies: string[] }> {
   if (userRootPath)
@@ -42,6 +49,9 @@ export async function readConfig(
       ? cwd // When user explicit provide config path, use current working directory as root
       : dirname(configPath) // Otherwise, use config file's directory as root
   )
+
+  if (chdir && rootPath !== process.cwd())
+    process.chdir(rootPath)
 
   console.log('Reading ESLint configs from', configPath)
   const { mod, dependencies } = await bundleRequire({

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -18,7 +18,7 @@ const configFilenames = [
 export interface ReadConfigOptions {
   cwd: string
   userConfigPath?: string
-  userRootPath?: string
+  userBasePath?: string
   /**
    * Change current working directory to rootPath
    * @default true
@@ -30,21 +30,21 @@ export async function readConfig(
   {
     cwd,
     userConfigPath,
-    userRootPath,
+    userBasePath,
     chdir = true,
   }: ReadConfigOptions,
 ): Promise<{ payload: Payload, dependencies: string[] }> {
-  if (userRootPath)
-    userRootPath = resolve(cwd, userRootPath)
+  if (userBasePath)
+    userBasePath = resolve(cwd, userBasePath)
 
   const configPath = userConfigPath
     ? resolve(cwd, userConfigPath)
-    : await findUp(configFilenames, { cwd: userRootPath || cwd })
+    : await findUp(configFilenames, { cwd: userBasePath || cwd })
 
   if (!configPath)
     throw new Error('Cannot find ESLint config file')
 
-  const rootPath = userRootPath || (
+  const rootPath = userBasePath || (
     userConfigPath
       ? cwd // When user explicit provide config path, use current working directory as root
       : dirname(configPath) // Otherwise, use config file's directory as root

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,13 +1,13 @@
 import { createServer } from 'node:http'
 import connect from 'connect'
 import sirv from 'sirv'
-import { createWsServer } from './ws'
+import { type CreateWsServerOptions, createWsServer } from './ws'
 import { distDir } from './dirs'
 
-export async function createHostServer() {
+export async function createHostServer(options: CreateWsServerOptions) {
   const app = connect()
 
-  const ws = await createWsServer()
+  const ws = await createWsServer(options)
 
   app.use('/api/payload.json', async (_req, res) => {
     res.setHeader('Content-Type', 'application/json')

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import { relative } from 'node:path'
 import chokidar from 'chokidar'
 import type { WebSocket } from 'ws'

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -4,15 +4,16 @@ import chokidar from 'chokidar'
 import type { WebSocket } from 'ws'
 import { WebSocketServer } from 'ws'
 import { getPort } from 'get-port-please'
-import { readConfig } from './configs'
+import { type ReadConfigOptions, readConfig } from './configs'
 import type { Payload } from '~~/types'
 
 const readErrorWarning = `Failed to load \`eslint.config.js\`.
 Note that \`@eslint/config-inspector\` only works with the flat config format:
 https://eslint.org/docs/latest/use/configure/configuration-files-new`
 
-export async function createWsServer() {
-  const cwd = process.cwd()
+export interface CreateWsServerOptions extends ReadConfigOptions {}
+
+export async function createWsServer(options: CreateWsServerOptions) {
   let payload: Payload | undefined
   const port = await getPort({ port: 7811, random: true })
   const wss = new WebSocketServer({
@@ -28,7 +29,7 @@ export async function createWsServer() {
 
   const watcher = chokidar.watch([], {
     ignoreInitial: true,
-    cwd: process.cwd(),
+    cwd: options.cwd,
     disableGlobbing: true,
   })
 
@@ -46,11 +47,11 @@ export async function createWsServer() {
   async function getData() {
     try {
       if (!payload) {
-        return await readConfig(cwd)
+        return await readConfig(options)
           .then((res) => {
             const _payload = payload = res.payload
             _payload.meta.wsPort = port
-            console.log(`Read ESLint config from \`${relative(cwd, _payload.meta.configPath)}\` with`, _payload.configs.length, 'configs and', Object.keys(_payload.rules).length, 'rules')
+            console.log(`Read ESLint config from \`${relative(options.cwd, _payload.meta.configPath)}\` with`, _payload.configs.length, 'configs and', Object.keys(_payload.rules).length, 'rules')
             watcher.add(res.dependencies)
             return payload
           })

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,7 @@ export interface ResolvedPayload extends Payload {
 export interface PayloadMeta {
   wsPort?: number
   lastUpdate: number
+  rootPath: string
   configPath: string
 }
 


### PR DESCRIPTION
fix #25

- Configs now resolved with `find-up`, aligning with ESLint
- When no arguments are provided, the cwd will be changed to the directory for the found config file
- When config path is provided, the cwd will keep at the command cwd
- When root path is provided but not the config, the config will be searched from the root path