### PR TITLE
fix: hide detail marker on safari

### DIFF
--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -5,7 +5,7 @@ html, body , #__nuxt{
 }
 
 summary::-webkit-details-marker {
-  display:none;
+  display: none;
 }
 
 body {

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -4,6 +4,10 @@ html, body , #__nuxt{
   padding: 0;
 }
 
+summary::-webkit-details-marker {
+  display:none;
+}
+
 body {
   --at-apply: bg-base color-base font-sans;
 }


### PR DESCRIPTION
| before | after |
|  ----  | ----  |
| ![IMG_0411](https://github.com/eslint/config-inspector/assets/38493346/9192a656-d311-4044-9ea3-dc41c204a99d)  | ![IMG_0410](https://github.com/eslint/config-inspector/assets/38493346/407bec3c-37f3-4408-b4e6-9bfbbb5cf6c7) |
