### PR TITLE
fix: use minimatch without `matchBase:true`

### DIFF
--- a/shared/configs.ts
+++ b/shared/configs.ts
@@ -1,7 +1,7 @@
 import { Minimatch } from 'minimatch'
 import type { FlatConfigItem, MatchedFile } from './types'
 
-const minimatchOpts = { dot: true, matchBase: true }
+const minimatchOpts = { dot: true }
 const _matchInstances = new Map<string, Minimatch>()
 
 function minimatch(file: string, pattern: string) {


### PR DESCRIPTION
Fixes #49

In flat config, patterns without a slash do not match at any level.

https://github.com/eslint/rewrite/blob/a136341eafbb092544d7aef19cc22f57104a572a/packages/config-array/src/config-array.js#L56-L63