### PR TITLE
Better handling for long config names

### DIFF
--- a/app/components/ConfigItem.vue
+++ b/app/components/ConfigItem.vue
@@ -60,15 +60,15 @@ const extraConfigs = computed(() => {
       <div class="absolute right-[calc(100%+10px)] top-1.5" text-right font-mono op35 lt-lg:hidden>
         #{{ index + 1 }}
       </div>
-      <div flex="~ gap-2 items-start wrap items-center" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono>
-        <div class="[details[open]_&]:rotate-90" i-ph-caret-right op50 transition />
-        <div flex flex-auto flex-col gap-3 md:flex-row>
-          <span :class="config.name ? '' : 'op50 italic'" flex-auto>
+      <div flex="~ gap-2 items-center" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono>
+        <div class="[details[open]_&]:rotate-90" i-ph-caret-right flex-none op50 transition />
+        <div flex flex-auto flex-col flex-wrap gap-3 md:flex-row md:justify-end>
+          <span :class="config.name ? '' : 'op50 italic'" flex-1>
             <ColorizedConfigName v-if="config.name" :name="config.name" />
             <span v-else>anonymous #{{ index + 1 }}</span>
           </span>
 
-          <div flex="~ gap-2 items-start wrap">
+          <div flex="~ gap-2 items-start">
             <SummarizeItem
               icon="i-ph-file-magnifying-glass-duotone"
               :number="config.files?.length || 0"

--- a/app/components/FileGroupItem.vue
+++ b/app/components/FileGroupItem.vue
@@ -114,7 +114,7 @@ function goToConfig(idx: number) {
       <div flex="~ col gap-1" ml6 mt--2>
         <div v-for="config, idx of group.configs" :key="idx" font-mono flex="~ gap-2">
           <VDropdown>
-            <button badge>
+            <button badge text-start>
               <ColorizedConfigName :name="config.name" :index="idx" />
             </button>
             <template #popper="{ shown }">


### PR DESCRIPTION
The config inspector does not handle long config names particularly well when there isn't enough screen width

## Configs page

In the configs page, the config name breaks in weird ways and, more importantly, misaligns the stats.

![image](https://github.com/eslint/config-inspector/assets/41266433/5fd94101-37b8-43b7-a75c-e85eb7ccce0a)

This PR makes it so that when there isn't enough screen width, the config name breaks first. Then if there still isn't enough, the stats wraps.

![image](https://github.com/eslint/config-inspector/assets/41266433/4a337961-d274-4edb-ae42-eef9b152d9c6)

![image](https://github.com/eslint/config-inspector/assets/41266433/92e59378-b149-4f62-9232-d2df337ad179)

## Files page

In the files page, the config name breaks but is centered.

![image](https://github.com/eslint/config-inspector/assets/41266433/ea8c4fd6-8e72-4c66-93a5-d21a43b23f62)

The PR makes the config name aligned

![image](https://github.com/eslint/config-inspector/assets/41266433/02073f87-7c56-4350-aca9-2602e36ec77a)

