### PR TITLE
fix: alignment hostname

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,7 @@ cli
     if (process.env.ESLINT_CONFIG)
       options.config ||= process.env.ESLINT_CONFIG
 
-    console.log(MARK_INFO, `Starting ESLint config inspector at`, c.green(`http://${host}:${port}`), '\n')
+    console.log(MARK_INFO, `Starting ESLint config inspector at`, c.green(`http://${host === '127.0.0.1' ? 'localhost' : host}:${port}`), '\n')
 
     const cwd = process.cwd()
     const server = await createHostServer({


### PR DESCRIPTION
If the hostname is localhost / 127.0.0.1, the log print host name and opened hostname are different:

![螢幕擷取畫面 2024-06-11 144025](https://github.com/eslint/config-inspector/assets/38133356/3d2786e9-c413-4cdd-bdd9-9182ed97a090)

So this PR alignment the print hostname with the opened hostname.

The opened hostname source:

https://github.com/eslint/config-inspector/blob/e7b655226c4d25bf623919b317bdc45a90eda6c4/src/cli.ts#L102-L106