### PR TITLE
fix: match default file patterns as well

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -104,13 +104,22 @@ export async function readConfig(
   if (!Array.isArray(rawConfigs))
     rawConfigs = [rawConfigs]
 
+  // ESLint applies these default configs to all files
+  // https://github.com/eslint/eslint/blob/21d3766c3f4efd981d3cc294c2c82c8014815e6e/lib/config/default-config.js#L66-L69
   rawConfigs.unshift(
     {
-      name: 'eslint/default-config',
+      name: 'eslint/defaults/ignores',
+      ignores: [
+        '**/node_modules/',
+        '.git/',
+      ],
+    } as FlatConfigItem,
+    {
+      name: 'eslint/defaults/files',
       files: ['**/*.js', '**/*.mjs'],
     } as FlatConfigItem,
     {
-      name: 'eslint/default-config/cjs',
+      name: 'eslint/defaults/files-cjs',
       files: ['**/*.cjs'],
       languageOptions: {
         sourceType: 'commonjs',

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -108,6 +108,17 @@ export async function readConfig(
   // https://github.com/eslint/eslint/blob/21d3766c3f4efd981d3cc294c2c82c8014815e6e/lib/config/default-config.js#L66-L69
   rawConfigs.unshift(
     {
+      name: 'eslint/defaults/languages',
+      languageOptions: {
+        sourceType: 'module',
+        ecmaVersion: 'latest',
+        parserOptions: {},
+      },
+      linterOptions: {
+        reportUnusedDisableDirectives: 1,
+      },
+    } as FlatConfigItem,
+    {
       name: 'eslint/defaults/ignores',
       ignores: [
         '**/node_modules/',

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -104,6 +104,21 @@ export async function readConfig(
   if (!Array.isArray(rawConfigs))
     rawConfigs = [rawConfigs]
 
+  rawConfigs.unshift(
+    {
+      name: 'eslint/default-config',
+      files: ['**/*.js', '**/*.mjs'],
+    } as FlatConfigItem,
+    {
+      name: 'eslint/default-config/cjs',
+      files: ['**/*.cjs'],
+      languageOptions: {
+        sourceType: 'commonjs',
+        ecmaVersion: 'latest',
+      },
+    } as FlatConfigItem,
+  )
+
   const rulesMap = new Map<string, RuleInfo>()
 
   // Try resolve `eslint` module from the same directory as the config file


### PR DESCRIPTION
The default config in ESLint is always prepended to the config before it uses the config, making it so that `**/*.js`, `**/*.mjs`, `**/*.cjs` are always matching file patterns: https://github.com/eslint/eslint/blob/21d3766c3f4efd981d3cc294c2c82c8014815e6e/lib/config/default-config.js#L66-L69

This PR copies those two configs and prepends them here as well, with some added names for them to make sense.

This is somewhat of a blunt fix. UI-wise it can be handled better and ideally one or more of `defaultConfig`, `FlatConfigArray` and `calculateConfigArray` would be exposed by ESLint so that this inspector can make use of the very same logic rather than attempt to reimplement it.

If additionally `defaultConfig` were to eg. add names, then this inspector could opt to eg. hide all `eslint/` prefixed rules and as such get the correct prepended config without having to confuse users with showing a config they never themselves added