### PR TITLE
fix: use `@eslint/config-array` to resolve paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "eslint": "^8.50.0 || ^9.0.0"
   },
   "dependencies": {
+    "@eslint/config-array": "^0.16.0",
+    "@voxpelli/config-array-find-files": "^0.1.2",
     "bundle-require": "^5.0.0",
     "cac": "^6.7.14",
     "chokidar": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     dependencies:
+      '@eslint/config-array':
+        specifier: ^0.16.0
+        version: 0.16.0
+      '@voxpelli/config-array-find-files':
+        specifier: ^0.1.2
+        version: 0.1.2(@eslint/config-array@0.16.0)
       bundle-require:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.21.5)
@@ -962,13 +968,25 @@ packages:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
 
+  '@nodelib/fs.scandir@3.0.0':
+    resolution: {integrity: sha512-ktI9+PxfHYtKjF3cLTUAh2N+b8MijCRPNwKJNqTVdL0gB0QxLU2rIRaZ1t71oEa3YBDE6bukH1sR0+CDnpp/Mg==}
+    engines: {node: '>=16.14.0'}
+
   '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
 
+  '@nodelib/fs.stat@3.0.0':
+    resolution: {integrity: sha512-2tQOI38s19P9i7X/Drt0v8iMA+KMsgdhB/dyPER+e+2Y8L1Z7QvnuRdW/uLuf5YRFUYmnj4bMA6qCuZHFI1GDQ==}
+    engines: {node: '>=16.14.0'}
+
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@2.0.0':
+    resolution: {integrity: sha512-54voNDBobGdMl3BUXSu7UaDh1P85PGHWlJ5e0XhPugo1JulOyCtp2I+5ri4wplGDJ8QGwPEQW7/x3yTLU7yF1A==}
+    engines: {node: '>=16.14.0'}
 
   '@npmcli/agent@2.2.2':
     resolution: {integrity: sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==}
@@ -1753,6 +1771,12 @@ packages:
 
   '@volar/typescript@2.3.0':
     resolution: {integrity: sha512-PtUwMM87WsKVeLJN33GSTUjBexlKfKgouWlOUIv7pjrOnTwhXHZNSmpc312xgXdTjQPpToK6KXSIcKu9sBQ5LQ==}
+
+  '@voxpelli/config-array-find-files@0.1.2':
+    resolution: {integrity: sha512-jOva73R+0Nc5/pyS/piBSjQzO4EehME7rPSkBpPC9PYSta+yj3OpF14v0m0HLLYLVNuyHbBjQh5QvGIZwTH2eA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@eslint/config-array': '>=0.16.0'
 
   '@vue-macros/common@1.10.3':
     resolution: {integrity: sha512-YSgzcbXrRo8a/TF/YIguqEmTld1KA60VETKJG8iFuaAfj7j+Tbdin3cj7/cYbcCHORSq1v9IThgq7r8keH7LXQ==}
@@ -6017,11 +6041,23 @@ snapshots:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
 
+  '@nodelib/fs.scandir@3.0.0':
+    dependencies:
+      '@nodelib/fs.stat': 3.0.0
+      run-parallel: 1.2.0
+
   '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.stat@3.0.0': {}
 
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.17.1
+
+  '@nodelib/fs.walk@2.0.0':
+    dependencies:
+      '@nodelib/fs.scandir': 3.0.0
       fastq: 1.17.1
 
   '@npmcli/agent@2.2.2':
@@ -7228,6 +7264,11 @@ snapshots:
       '@volar/language-core': 2.3.0
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
+
+  '@voxpelli/config-array-find-files@0.1.2(@eslint/config-array@0.16.0)':
+    dependencies:
+      '@eslint/config-array': 0.16.0
+      '@nodelib/fs.walk': 2.0.0
 
   '@vue-macros/common@1.10.3(rollup@3.29.4)(vue@3.4.29(typescript@5.5.2))':
     dependencies:


### PR DESCRIPTION
Fixes #59

Following the discussions in https://github.com/eslint/eslint/issues/18619 I went ahead and made a proof of concept extraction of the small core logic that ESLint uses to iterate over the files of a directory, using a `ConfigArray` as guidance.

I published it at [`configArrayFindFiles()`](https://github.com/voxpelli/config-array-find-files) and here is a PR that makes use if it.

It uses a fake schema to load the configs into `ConfigArray` as there is no published official one that can be used yet (https://github.com/eslint/eslint/issues/18619#issuecomment-2183187174)

Hopefully `@eslint/config-array` itself will get a `configArrayFindFiles()` equivalent eventually, but we need to start somewhere.

The way that `configArrayFindFiles()` is constructed it could also simplify ESLint's `globSearch()` as well if it were to be upstreamed to `@eslint/config-array`, as it would separate the concerns of matching by `ConfigArray` files and ignores and matching by the globs sent into `globSearch()` when someone wants to lint a set of files.