### PR TITLE
fix: move toggleRuleView to page rules

### DIFF
--- a/app/components/NavBar.vue
+++ b/app/components/NavBar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useTimeAgo } from '@vueuse/core'
-import { filtersRules as filters, stateStorage } from '~/composables/state'
+import { filtersRules as filters } from '~/composables/state'
 import { useRouter } from '#app/composables/router'
 import { isFetching, payload } from '~/composables/payload'
 import { toggleDark } from '~/composables/dark'
@@ -21,10 +21,6 @@ function showDeprecated() {
 
   if (router.currentRoute.value.path !== '/rules')
     router.push('/rules')
-}
-
-function toggleRuleView() {
-  stateStorage.value.viewType = stateStorage.value.viewType === 'list' ? 'grid' : 'list'
 }
 </script>
 
@@ -77,13 +73,6 @@ function toggleRuleView() {
       title="Toggle Dark Mode"
       i-ph-sun-dim-duotone dark:i-ph-moon-stars-duotone ml1 text-xl op50 hover:op75
       @click="toggleDark()"
-    />
-    <button
-      title="Toggle Rule View"
-
-      :class="stateStorage.viewType === 'list' ? 'i-ph-list-duotone' : 'i-ph-grid-four-duotone'"
-      text-xl op50 lt-md:hidden hover:op75
-      @click="toggleRuleView()"
     />
     <NuxtLink
       href="https://github.com/eslint/config-inspector" target="_blank"

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -27,7 +27,7 @@ export const stateStorage = useLocalStorage(
 )
 
 const bp = useBreakpoints(breakpointsTailwind)
-const bpSm = bp.smallerOrEqual('md')
+export const bpSm = bp.smallerOrEqual('md')
 
 export const isGridView = computed(() => bpSm.value || stateStorage.value.viewType === 'grid')
 

--- a/app/pages/rules.vue
+++ b/app/pages/rules.vue
@@ -2,7 +2,7 @@
 import { debouncedWatch } from '@vueuse/core'
 import { computed, ref } from 'vue'
 import Fuse from 'fuse.js'
-import { filtersRules as filters } from '~/composables/state'
+import { bpSm, filtersRules as filters, stateStorage } from '~/composables/state'
 import { payload } from '~/composables/payload'
 
 const rules = computed(() => Object.values(payload.value.rules))
@@ -164,28 +164,49 @@ function resetFilters() {
       </div>
     </div>
 
-    <div flex="~ gap-2">
-      <div
-        flex="~ inline gap-2 items-center"
-        border="~ gray/20 rounded-full" bg-gray:10 px3 py1
-      >
-        <div i-ph-list-checks-duotone />
-        <span>{{ filtered.length }}</span>
-        <span op75>rules {{ isDefaultFilters ? 'enabled' : 'filtered' }}</span>
-        <span text-sm op50>out of {{ rules.length }} rules</span>
-      </div>
-      <button
-        v-if="!isDefaultFilters"
-        flex="~ inline gap-2 items-center"
-        border="~ purple/20 rounded-full" bg-purple:10 px3 py1
-        @click="resetFilters()"
-      >
-        <div i-ph-funnel-duotone text-purple />
-        <span op50>Clear Filter</span>
+    <div items-center justify-between md:flex>
+      <div flex="~ gap-2" lt-sm:flex-col>
+        <div
+          flex="~ inline gap-2 items-center"
+          border="~ gray/20 rounded-full" bg-gray:10 px3 py1
+        >
+          <div i-ph-list-checks-duotone />
+          <span>{{ filtered.length }}</span>
+          <span op75>rules {{ isDefaultFilters ? 'enabled' : 'filtered' }}</span>
+          <span text-sm op50>out of {{ rules.length }} rules</span>
+        </div>
         <button
-          i-ph-x ml--1 text-sm op25 hover:op100
-        />
-      </button>
+          v-if="!isDefaultFilters"
+          flex="~ inline gap-2 items-center self-start"
+          border="~ purple/20 rounded-full" bg-purple:10 px3 py1
+          @click="resetFilters()"
+        >
+          <div i-ph-funnel-duotone text-purple />
+          <span op50>Clear Filter</span>
+          <button
+            i-ph-x ml--1 text-sm op25 hover:op100
+          />
+        </button>
+      </div>
+
+      <div v-if="!bpSm" flex="~ gap-1">
+        <button
+          btn-action
+          :class="{ 'btn-action-active': stateStorage.viewType === 'list' }"
+          @click="stateStorage.viewType = 'list'"
+        >
+          <div i-ph-list-duotone />
+          List
+        </button>
+        <button
+          btn-action
+          :class="{ 'btn-action-active': stateStorage.viewType === 'grid' }"
+          @click="stateStorage.viewType = 'grid'"
+        >
+          <div i-ph-grid-four-duotone />
+          Grid
+        </button>
+      </div>
     </div>
     <RuleList
       my4


### PR DESCRIPTION
When users are not in page rules and clicking the toggleRuleView button, nothing woud happen.

It's strange.

So this PR moves the `toggleRuleView` button to page rules.

This is how it looks like now:

<img width="1915" alt="Screenshot 2024-07-09 at 22 07 08" src="https://github.com/eslint/config-inspector/assets/22659150/a47b3764-5752-4d9f-b534-f81b4f5ac1a8">

---

Besides, a little style change made to rules filter.

Before:

<img width="392" alt="Screenshot 2024-07-09 at 22 08 57" src="https://github.com/eslint/config-inspector/assets/22659150/a18637c7-b6a7-4746-8649-6df3045ded8b">

After:

<img width="386" alt="Screenshot 2024-07-09 at 22 09 16" src="https://github.com/eslint/config-inspector/assets/22659150/a1b66666-b1aa-4462-a853-43bcd644c986">






