### PR TITLE
fix: label of "Rules" -> "Configs" on file group

### DIFF
--- a/app/components/FileGroupItem.vue
+++ b/app/components/FileGroupItem.vue
@@ -93,7 +93,7 @@ function goToConfig(idx: number) {
               icon="i-ph-stack-duotone"
               :number="group.configs.length"
               color="text-blue5 dark:text-blue4"
-              title="Rules"
+              title="Configs"
               mr-2
             />
           </div>


### PR DESCRIPTION
Was confused by this until realizing the caption was referring to configs instead.

(It would incidentally be nice to have applicable rules listed if possible, but that's another issue.)