### PR TITLE
fix: `nth` formatting for values above 20

### DIFF
--- a/app/composables/strings.ts
+++ b/app/composables/strings.ts
@@ -1,10 +1,11 @@
 export function nth(n: number) {
-  if (n === 1)
-    return '1st'
-  if (n === 2)
-    return '2nd'
-  if (n === 3)
-    return '3rd'
+  const nString = `${n}`
+  if (nString.endsWith('1') && n !== 11)
+    return `${nString}st`
+  if (nString.endsWith('2') && n !== 12)
+    return `${nString}nd`
+  if (nString.endsWith('3') && n !== 13)
+    return `${nString}rd`
   return `${n}th`
 }
 


### PR DESCRIPTION
While 11th, 12th, 13th uses `th` all other numbers that end with 1, 2 or 3 use same suffix as the base 1, 2 and 3

For reference, see eg: https://www.mathsisfun.com/numbers/cardinal-ordinal-chart.html

Fixes #74