### PR TITLE
feat: improved errors when config can not be found

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,8 @@ import process from 'node:process'
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
+import { types } from 'node:util'
+
 import open from 'open'
 import { getPort } from 'get-port-please'
 import cac from 'cac'
@@ -39,6 +41,11 @@ cli
       userBasePath: options.basePath,
       globMatchedFiles: options.files,
     })
+
+    if (types.isNativeError(configs)) {
+      configs.prettyPrint()
+      process.exit(1)
+    }
 
     let baseURL = options.base
     if (!baseURL.endsWith('/'))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,6 @@ import process from 'node:process'
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
-import { types } from 'node:util'
 
 import open from 'open'
 import { getPort } from 'get-port-please'
@@ -13,6 +12,7 @@ import { createHostServer } from './server'
 import { distDir } from './dirs'
 import { readConfig } from './configs'
 import { MARK_CHECK, MARK_INFO } from './constants'
+import { ConfigInspectorError } from './errors'
 
 const cli = cac(
   'eslint-config-inspector',
@@ -35,16 +35,22 @@ cli
 
     const cwd = process.cwd()
     const outDir = resolve(cwd, options.outDir)
-    const configs = await readConfig({
-      cwd,
-      userConfigPath: options.config,
-      userBasePath: options.basePath,
-      globMatchedFiles: options.files,
-    })
 
-    if (types.isNativeError(configs)) {
-      configs.prettyPrint()
-      process.exit(1)
+    let configs
+    try {
+      configs = await readConfig({
+        cwd,
+        userConfigPath: options.config,
+        userBasePath: options.basePath,
+        globMatchedFiles: options.files,
+      })
+    }
+    catch (error) {
+      if (error instanceof ConfigInspectorError) {
+        error.prettyPrint()
+        process.exit(1)
+      }
+      throw error
     }
 
     let baseURL = options.base

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,14 @@ export const configFilenames = [
   'eslint.config.cts',
 ]
 
+export const legacyConfigFilenames = [
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.eslintrc.yaml',
+  '.eslintrc.yml',
+  '.eslintrc.json',
+]
+
 export const MARK_CHECK = c.green('✔')
 export const MARK_INFO = c.blue('ℹ')
+export const MARK_ERROR = c.red('✖')

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,49 @@
+import c from 'picocolors'
+import { MARK_ERROR } from './constants'
+
+export class ConfigInspectorError extends Error {
+  prettyPrint() {
+    console.error(MARK_ERROR, this.message)
+  }
+}
+
+export class ConfigPathError extends ConfigInspectorError {
+  override name = 'ConfigPathError' as const
+
+  constructor(
+    public basePath: string,
+    public configFilenames: string[],
+  ) {
+    super('Cannot find ESLint config file')
+  }
+
+  override prettyPrint() {
+    console.error(MARK_ERROR, this.message, c.dim(`
+
+Looked in ${c.underline(this.basePath)} and parent folders for:
+
+ * ${this.configFilenames.join('\n * ')}`,
+    ))
+  }
+}
+
+export class ConfigPathLegacyError extends ConfigInspectorError {
+  override name = 'ConfigPathLegacyError' as const
+
+  constructor(
+    public basePath: string,
+    public configFilename: string,
+  ) {
+    super('Found ESLint legacy config file')
+  }
+
+  override prettyPrint() {
+    console.error(MARK_ERROR, this.message, c.dim(`
+
+Encountered unsupported legacy config ${c.underline(this.configFilename)} in ${c.underline(this.basePath)}
+
+\`@eslint/config-inspector\` only works with the new flat config format:
+https://eslint.org/docs/latest/use/configure/configuration-files-new`,
+    ))
+  }
+}


### PR DESCRIPTION
Fixes #82

When encountering no flat config it now checks for a legacy config and if found it will output this error message now:

![Skärmavbild 2024-08-15 kl  15 03 25](https://github.com/user-attachments/assets/88f3bfc2-27a3-42db-bbbf-e1a380b26516)

And if no legacy config file is found either, then it will tell the user what files it looked for and in what folder:

![Skärmavbild 2024-08-15 kl  15 03 43](https://github.com/user-attachments/assets/76de8e94-1834-4eea-a6b0-a342bf7560c6)
