### PR TITLE
docs: add CLI options to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Visit http://localhost:7777/ to view and play with your ESLint config. Changes t
 | `--open` | Open browser | `true` |
 | `-h, --help` | Display help text | - |
 
-This table accurately represents the CLI output you provided, with each option, its description, and default value (where applicable) in a clear, tabular format.
-
 ### Online Preview
 
 Or play it right in your browser now:

--- a/README.md
+++ b/README.md
@@ -20,17 +20,7 @@ npx @eslint/config-inspector@latest
 
 Visit http://localhost:7777/ to view and play with your ESLint config. Changes to the config file will be updated automatically.
 
-### CLI Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--config <configFile>` | Config file path | - |
-| `--files` | Include matched file paths in payload | `true` |
-| `--basePath <basePath>` | Base directory for globs to resolve. Default to directory of config file if not provided | - |
-| `--host <host>` | Host | `127.0.0.1` |
-| `--port <port>` | Port | `7777` |
-| `--open` | Open browser | `true` |
-| `-h, --help` | Display help text | - |
+Run `npx @eslint/config-inspector --help` to see all the CLI options available.
 
 ### Online Preview
 
@@ -48,16 +38,7 @@ npx @eslint/config-inspector build
 
 This will generate a Single-Page Application (SPA) under `.eslint-config-inspector`, with the snapshot of the current ESLint config. You can deploy it somewhere, or use it for comparison etc.
 
-### Build Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--config <configFile>` | Config file path | - |
-| `--files` | Include matched file paths in payload | `true` |
-| `--basePath <basePath>` | Base directory for globs to resolve. Default to directory of config file if not provided | - |
-| `--base <baseURL>` | Base URL for deployment | `/` |
-| `--outDir <dir>` | Output directory | `.eslint-config-inspector` |
-| `-h, --help` | Display help text | - |
+Run `npx @eslint/config-inspector build --help` to see all the CLI options available.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ npx @eslint/config-inspector@latest
 
 Visit http://localhost:7777/ to view and play with your ESLint config. Changes to the config file will be updated automatically.
 
+### CLI Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--config <configFile>` | Config file path | - |
+| `--files` | Include matched file paths in payload | `true` |
+| `--basePath <basePath>` | Base directory for globs to resolve. Default to directory of config file if not provided | - |
+| `--host <host>` | Host | `127.0.0.1` |
+| `--port <port>` | Port | `7777` |
+| `--open` | Open browser | `true` |
+| `-h, --help` | Display help text | - |
+
+This table accurately represents the CLI output you provided, with each option, its description, and default value (where applicable) in a clear, tabular format.
+
 ### Online Preview
 
 Or play it right in your browser now:
@@ -35,6 +49,17 @@ npx @eslint/config-inspector build
 ```
 
 This will generate a Single-Page Application (SPA) under `.eslint-config-inspector`, with the snapshot of the current ESLint config. You can deploy it somewhere, or use it for comparison etc.
+
+### Build Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--config <configFile>` | Config file path | - |
+| `--files` | Include matched file paths in payload | `true` |
+| `--basePath <basePath>` | Base directory for globs to resolve. Default to directory of config file if not provided | - |
+| `--base <baseURL>` | Base URL for deployment | `/` |
+| `--outDir <dir>` | Output directory | `.eslint-config-inspector` |
+| `-h, --help` | Display help text | - |
 
 ## Contributing
 


### PR DESCRIPTION
Related to #87 

I didn't know there was a `--base` CLI option (I should have tried `--help`, but I assumed there were no options from looking at the readme), this just reformats the `--help` output as a markdown table.