### PR TITLE
feat: display rule deprecated info

### DIFF
--- a/app/components/RuleDeprecatedInfo.vue
+++ b/app/components/RuleDeprecatedInfo.vue
@@ -1,0 +1,100 @@
+<script lang="ts" setup>
+import type { RuleInfo } from '~~/shared/types'
+import { Dropdown as VDropdown } from 'floating-vue'
+import { computed } from 'vue'
+
+const {
+  deprecated,
+  invalid,
+} = defineProps<{
+  deprecated: RuleInfo['deprecated']
+  invalid: RuleInfo['invalid']
+}>()
+
+const deprecatedInfo = computed(() => {
+  if (!deprecated || typeof deprecated === 'boolean')
+    return
+
+  return deprecated
+})
+
+const versionInfo = computed(() => {
+  if (!deprecatedInfo.value)
+    return
+
+  let res = ''
+
+  if (deprecatedInfo.value.deprecatedSince)
+    res += `was deprecated in v${deprecatedInfo.value.deprecatedSince}`
+
+  if (deprecatedInfo.value.availableUntil) {
+    if (res)
+      res += ', and '
+
+    res += `will be removed in v${deprecatedInfo.value.availableUntil}`
+  }
+  return `This rule ${res}.`
+})
+
+function getLinkClass(url: string | undefined) {
+  return [
+    'text-blue5 dark:text-blue4',
+    url ? 'underline' : '',
+  ]
+}
+</script>
+
+<template>
+  <VDropdown
+    inline-block
+    :disabled="!deprecatedInfo"
+  >
+    <div
+      border="~ red/25 rounded"
+      select-none bg-red:5 px1 text-xs text-red
+    >
+      {{ invalid ? 'INVALID' : 'DEPRECATED' }}
+    </div>
+    <template #popper="{ shown }">
+      <div
+        v-if="shown && deprecatedInfo"
+        p-2 text-sm op75
+      >
+        <p v-if="deprecatedInfo.message" mb1 flex="~ gap-1" text-red>
+          <span i-ph-warning-duotone inline-block />{{ deprecatedInfo.message }}
+        </p>
+        <p v-if="versionInfo">
+          {{ versionInfo }}
+        </p>
+        <p v-if="deprecatedInfo.replacedBy?.length">
+          Please use the
+          <template v-for="({ rule, plugin }, i) in deprecatedInfo.replacedBy">
+            <NuxtLink
+              v-if="rule"
+              :key="rule.name"
+              :class="getLinkClass(rule.url)"
+              :href="rule.url"
+              target="_blank"
+            >
+              {{ rule.name ?? rule.url }}
+            </NuxtLink>
+            <template v-if="plugin">
+              in
+              <NuxtLink
+                :key="plugin.name"
+                :class="getLinkClass(plugin.url)"
+                :href="plugin.url"
+                target="_blank"
+              >
+                {{ plugin.name ?? plugin.url }}
+              </NuxtLink>
+            </template>{{ i === deprecatedInfo.replacedBy.length - 1 ? '.' : i === 0 ? '' : ', ' }}
+          </template>
+        </p>
+        <p mt2>
+          <a text-red underline :href="deprecatedInfo.url">Learn more</a>
+        </p>
+      </div>
+    </template>
+  </VDropdown>
+</template>

--- a/app/components/RuleDeprecatedInfo.vue
+++ b/app/components/RuleDeprecatedInfo.vue
@@ -8,7 +8,7 @@ const {
   invalid,
 } = defineProps<{
   deprecated: RuleInfo['deprecated']
-  invalid: RuleInfo['invalid']
+  invalid: RuleInfo['invalid'] | undefined
 }>()
 
 const deprecatedInfo = computed(() => {

--- a/app/components/RuleItem.vue
+++ b/app/components/RuleItem.vue
@@ -131,9 +131,11 @@ function capitalize(str?: string) {
     >
       {{ rule.invalid ? 'Invalid rule has no description' : capitalize(rule.docs?.description) }}
     </div>
-    <div v-if="!gridView && (rule.invalid || rule.deprecated)" border="~ red/25 rounded" bg-red:5 px1 text-xs text-red>
-      {{ rule.invalid ? 'INVALID' : 'DEPRECATED' }}
-    </div>
+    <RuleDeprecatedInfo
+      v-if="!gridView && (rule.invalid || rule.deprecated)"
+      :deprecated="rule.deprecated"
+      :invalid="rule.invalid"
+    />
   </div>
 
   <div
@@ -141,9 +143,11 @@ function capitalize(str?: string) {
     flex flex-auto flex-col items-start justify-end
   >
     <div flex="~ gap-2" mt1>
-      <div v-if="rule.invalid || rule.deprecated" border="~ red/25 rounded" bg-red:5 px1 text-xs text-red>
-        {{ rule.invalid ? 'INVALID' : 'DEPRECATED' }}
-      </div>
+      <RuleDeprecatedInfo
+        v-if="rule.invalid || rule.deprecated"
+        :deprecated="rule.deprecated"
+        :invalid="rule.invalid"
+      />
       <div
         v-if="rule.docs?.recommended"
         v-tooltip="'✅ Recommended'"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

#### What changes did you make? (Give an overview)

Add a dropdown to display deprecated information from plugins.

Dark mode:
<img width="456" height="219" alt="image" src="https://github.com/user-attachments/assets/cb305800-6249-426b-a24b-8a2b830afc4f" />

Light mode:
<img width="461" height="226" alt="image" src="https://github.com/user-attachments/assets/d4533cbb-2b6a-4bf3-a097-b00392c6c7e0" />


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I'm not sure if the style is ok. Some suggestions are welcome. :)
