### PR TITLE
fix: cli entrypoint import path

### DIFF
--- a/bin.mjs
+++ b/bin.mjs
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 // eslint-disable-next-line antfu/no-top-level-await
-await import('./dist/cli.js')
+await import('./dist/cli.mjs')


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

fix the import path, the cli.js has been renamed to cli.mjs

#### What changes did you make? (Give an overview)

fix the import path

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

fixes #186

#### Is there anything you'd like reviewers to focus on?
