### PR TITLE
chore: allow eslint version ^10.0.0 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "nuxt typecheck"
   },
   "peerDependencies": {
-    "eslint": "^8.50.0 || ^9.0.0"
+    "eslint": "^8.50.0 || ^9.0.0 || ^10.0.0"
   },
   "dependencies": {
     "ansis": "catalog:",


### PR DESCRIPTION
#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### What changes did you make?
I added `^10.0.0` to the list of allowed versions for `eslint` as a peer dependency to suppress related warnings when installing the package. I don't think any other change is necessary as the package seems to work fine with v10.
