### PR TITLE
fix: missing replacement of `baseURL` in cli

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,7 @@ cli
         const newContent = content
           .replaceAll(/\s(href|src)="\//g, ` $1="${baseURL}`)
           .replaceAll('baseURL:"/"', `baseURL:"${baseURL}"`)
+          .replaceAll('"#entry":"/_nuxt/', `"#entry":"${baseURL}_nuxt/`)
         await fs.writeFile(resolve(outDir, file), newContent, 'utf-8')
       }
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fixing a bug about a missing placement of `baseURL`, which cause a 404 call and make the product built with `--base` fails to load

#### What changes did you make? (Give an overview)

Problem comes from `dist/public/index.html` and `src/cli.ts`
```js
// dist/public/index.html
<script type="importmap">{"imports":{"#entry":"/_nuxt/DDzlGqL0.js"}}</script>
```
```js
// src/cli.ts
if (baseURL !== '/') {
  for (const file of htmlFiles) {
    const content = await fs.readFile(resolve(distDir, file), 'utf-8')
    const newContent = content
      .replaceAll(/\s(href|src)="\//g, ` $1="${baseURL}`)
      .replaceAll('baseURL:"/"', `baseURL:"${baseURL}"`)
    await fs.writeFile(resolve(outDir, file), newContent, 'utf-8')
  }
}
```
Where the current `repalceAll()` are not able to change the `#entry` path according to the `baseURL`

I tried to add one more `replaceAll()` so that it get covered.
```js
// src/cli.ts
if (baseURL !== '/') {
  for (const file of htmlFiles) {
    const content = await fs.readFile(resolve(distDir, file), 'utf-8')
    const newContent = content
      .replaceAll(/\s(href|src)="\//g, ` $1="${baseURL}`)
      .replaceAll('baseURL:"/"', `baseURL:"${baseURL}"`)
      .replaceAll('"#entry":"/_nuxt/', `"#entry":"${baseURL}_nuxt/`) // <-- here
    await fs.writeFile(resolve(outDir, file), newContent, 'utf-8')
  }
}
```

#### Related Issues

fix #221

#### Is there anything you'd like reviewers to focus on?