### PR TITLE
feat!: change default `--outDir` to `dist/__eslint-config-inspector`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ dist
 .env
 .idea/
 .DS_Store
-.eslint-config-inspector
 public/fonts
 *.code-workspace
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is also possible to build a static web app for your ESLint config:
 npx @eslint/config-inspector build
 ```
 
-This will generate a Single-Page Application (SPA) under `.eslint-config-inspector`, with the snapshot of the current ESLint config. You can deploy it somewhere, or use it for comparison etc.
+This will generate a Single-Page Application (SPA) under `dist/__eslint-config-inspector`, with the snapshot of the current ESLint config. You can deploy it somewhere, or use it for comparison etc.
 
 Run `npx @eslint/config-inspector build --help` to see all the CLI options available.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ cli
   .option('--files', 'Include matched file paths in payload', { default: true })
   .option('--basePath <basePath>', 'Base directory for globs to resolve. Default to directory of config file if not provided')
   .option('--base <baseURL>', 'Base URL for deployment', { default: '/' })
-  .option('--outDir <dir>', 'Output directory', { default: '.eslint-config-inspector' })
+  .option('--outDir <dir>', 'Output directory', { default: 'dist/__eslint-config-inspector' })
   .action(async (options) => {
     if (process.env.ESLINT_CONFIG)
       options.config ||= process.env.ESLINT_CONFIG


### PR DESCRIPTION
## Summary

- Change the default `--outDir` for `eslint-config-inspector build` from `.eslint-config-inspector` to `dist/__eslint-config-inspector` so the output lives under the conventional `dist/` directory.
- Update the README static-build section to reflect the new default path.
- Remove the now-obsolete `.eslint-config-inspector` entry from `.gitignore` (the new default is covered by the existing `dist` ignore).

## Breaking change

Users running `npx @eslint/config-inspector build` without `--outDir` will see output land at `dist/__eslint-config-inspector/` instead of `.eslint-config-inspector/`. To keep the old path, pass `--outDir .eslint-config-inspector` explicitly.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `node bin.mjs build --help` shows the new default
- [ ] Running `build` without `--outDir` writes to `dist/__eslint-config-inspector/`
- [ ] Running `build --outDir custom-dir` still respects the override