### PR TITLE
feat: use jiti to load config files, align with ESLint CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,10 @@
   },
   "dependencies": {
     "ansis": "catalog:",
-    "bundle-require": "catalog:",
     "cac": "catalog:",
     "chokidar": "catalog:",
     "devframe": "catalog:",
-    "esbuild": "catalog:",
+    "jiti": "catalog:",
     "tinyglobby": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ catalogs:
     ansis:
       specifier: ^4.2.0
       version: 4.2.0
-    bundle-require:
-      specifier: ^5.1.0
-      version: 5.1.0
     cac:
       specifier: ^7.0.0
       version: 7.0.0
@@ -84,6 +81,9 @@ catalogs:
     fuse.js:
       specifier: ^7.3.0
       version: 7.3.0
+    jiti:
+      specifier: ^2.6.1
+      version: 2.6.1
     lint-staged:
       specifier: ^17.0.4
       version: 17.0.4
@@ -151,9 +151,6 @@ importers:
       ansis:
         specifier: 'catalog:'
         version: 4.2.0
-      bundle-require:
-        specifier: 'catalog:'
-        version: 5.1.0(esbuild@0.28.0)
       cac:
         specifier: 'catalog:'
         version: 7.0.0
@@ -163,9 +160,9 @@ importers:
       devframe:
         specifier: 'catalog:'
         version: 0.1.22(typescript@6.0.3)
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
+      jiti:
+        specifier: 'catalog:'
+        version: 2.6.1
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,6 @@ catalog:
   '@unocss/nuxt': ^66.6.8
   '@vueuse/nuxt': ^14.3.0
   ansis: ^4.2.0
-  bundle-require: ^5.1.0
   cac: ^7.0.0
   chokidar: ^5.0.0
   devframe: ^0.1.22
@@ -34,6 +33,7 @@ catalog:
   find-up: ^8.0.0
   floating-vue: ^5.2.2
   fuse.js: ^7.3.0
+  jiti: ^2.6.1
   lint-staged: ^17.0.4
   minimatch: ^10.2.5
   mlly: ^1.8.2

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,11 +1,13 @@
 import type { ConfigArray } from '@eslint/config-array'
 import type { Linter } from 'eslint'
 import type { FlatConfigItem, MatchedFile, Payload, RuleInfo } from '../shared/types'
+import { statSync } from 'node:fs'
 import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import fswalk from '@nodelib/fs.walk'
 import c from 'ansis'
-import { bundleRequire } from 'bundle-require'
 import { findUp } from 'find-up'
+import { createJiti } from 'jiti'
 import { resolve as resolveModule } from 'mlly'
 import { basename, dirname, normalize, relative, resolve } from 'pathe'
 import { buildConfigArray, matchFile } from '../shared/configs'
@@ -104,8 +106,9 @@ export interface ESLintConfig {
  *
  * Accept an options object to specify the working directory path and overrides.
  *
- * It uses `bundle-requires` load the config file and find it's dependencies.
- * It always get the latest version of the config file (no ESM cache).
+ * It uses `jiti` to load the config file (the same loader ESLint itself uses).
+ * Each call creates a fresh jiti instance and busts the ESM cache via an
+ * `mtime` URL query param, so the latest version of the config is always read.
  */
 export async function readConfig(
   options: ReadConfigOptions,
@@ -122,13 +125,14 @@ export async function readConfig(
     process.chdir(basePath)
 
   console.log(MARK_INFO, `Reading ESLint config from`, c.blue(configPath))
-  const { mod, dependencies } = await bundleRequire({
-    filepath: configPath,
-    cwd: basePath,
-    tsconfig: false,
-  })
+  const jiti = createJiti(import.meta.url, { moduleCache: false })
+  const fileURL = pathToFileURL(configPath)
+  fileURL.searchParams.set('mtime', String(statSync(configPath).mtimeMs))
+  const mod = await jiti.import(fileURL.href)
 
-  let rawConfigs = await (mod.default ?? mod) as FlatConfigItem[]
+  const dependencies = collectJitiDependencies(jiti, configPath)
+
+  let rawConfigs = ((mod as any)?.default ?? mod) as FlatConfigItem[]
 
   // A single flat config object is also valid
   if (!Array.isArray(rawConfigs))
@@ -244,6 +248,30 @@ export async function readConfig(
     dependencies,
     payload,
   }
+}
+
+/**
+ * Best-effort dependency collection from a `jiti` instance's internal module
+ * cache, used by the dev-mode watcher to reload when imported files change.
+ *
+ * jiti 2.x has no public dep-tracking API; we read the `cache` property if it
+ * is present and walk its keys. If the shape ever changes, we fall back to
+ * watching just the config file, which matches ESLint's own behavior.
+ */
+function collectJitiDependencies(jiti: unknown, configPath: string): string[] {
+  const deps = new Set<string>([configPath])
+  const cache = (jiti as { cache?: unknown }).cache
+  let keys: string[] = []
+  if (cache instanceof Map)
+    keys = [...cache.keys()].filter((k): k is string => typeof k === 'string')
+  else if (cache && typeof cache === 'object')
+    keys = Object.keys(cache as Record<string, unknown>)
+  for (const key of keys) {
+    const path = key.startsWith('file://') ? fileURLToPath(key) : key
+    if (path && !path.includes('/node_modules/'))
+      deps.add(path)
+  }
+  return [...deps]
 }
 
 export async function globMatchedFiles(

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -132,11 +132,14 @@ export async function readConfig(
 
   const dependencies = collectJitiDependencies(jiti, configPath)
 
-  let rawConfigs = ((mod as any)?.default ?? mod) as FlatConfigItem[]
+  const exported = ((mod as any)?.default ?? mod) as FlatConfigItem | FlatConfigItem[]
 
-  // A single flat config object is also valid
-  if (!Array.isArray(rawConfigs))
-    rawConfigs = [rawConfigs]
+  // A single flat config object is also valid. Always clone into a fresh
+  // array so the ESLint defaults `unshift`ed below don't mutate the user's
+  // exported array — Node's ESM loader caches modules by URL, so a second
+  // load of an unchanged config would otherwise return the same reference
+  // and accumulate defaults on each call.
+  const rawConfigs: FlatConfigItem[] = Array.isArray(exported) ? [...exported] : [exported]
 
   // ESLint applies these default configs to all files
   // https://github.com/eslint/eslint/blob/21d3766c3f4efd981d3cc294c2c82c8014815e6e/lib/config/default-config.js#L66-L69


### PR DESCRIPTION
## Summary

- Replace `bundle-require` (esbuild-backed) with `jiti` for loading `eslint.config.*`, mirroring how ESLint itself loads configs in [`lib/config/config-loader.js`](https://github.com/eslint/eslint/blob/main/lib/config/config-loader.js).
- Fresh `createJiti(..., { moduleCache: false })` per call + `?mtime=` URL cache-bust + manual `mod.default ?? mod` unwrap — exactly matching ESLint's pattern.
- Dev-mode watcher walks `jiti.cache` best-effort to keep transitive imports under watch, falling back to watching only the config file (matches ESLint).
- Drops `bundle-require` and `esbuild` from runtime dependencies; adds `jiti ^2.6.1` (already a transitive of ESLint).

Fixes #238. Resolves the divergence class behind #95: configs that work from the ESLint CLI but failed inside the inspector due to different module-resolution/transform pipelines.

## Test plan

- [x] `pnpm install` — `bundle-require` no longer a direct dep, `jiti@2.6.1` elevated, lockfile clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 9/9 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` + CLI smoke against repo's own `eslint.config.js` (top-level `await`, dynamic imports) → 61 configs / 1413 rules
- [x] CLI smoke against a TS config with `import type` + type assertions → loads
- [x] CLI smoke against a CJS config with `module.exports = [...]` → interop unwrap works