### PR TITLE
test: add Playwright e2e tests for CLI dev and build modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,40 @@ jobs:
 
       - name: Test
         run: nr test
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Set node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Setup
+        run: npm i -g @antfu/ni
+
+      - name: Install
+        run: nci
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build
+        run: nr build
+
+      - name: Run e2e tests
+        run: nr test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ dist
 .DS_Store
 .eslint-config-inspector
 public/fonts
+
+# Playwright e2e
+tests/e2e/.output
+playwright-report
+test-results
+.playwright
 *.code-workspace
 
 # Automatically generated files by GitHub Actions workflow

--- a/app/components/ConfigItem.vue
+++ b/app/components/ConfigItem.vue
@@ -66,6 +66,7 @@ const extraConfigs = computed(() => {
     :open="open"
     border="~ rounded-lg" relative
     :class="active ? 'border-yellow:70' : 'border-base'"
+    data-testid="config-item"
     @toggle="open = ($event.target as any).open"
   >
     <summary block>

--- a/app/components/FileItem.vue
+++ b/app/components/FileItem.vue
@@ -25,7 +25,7 @@ function searchFile() {
 </script>
 
 <template>
-  <div flex="~ gap-2 items-center">
+  <div flex="~ gap-2 items-center" data-testid="file-item">
     <div :class="icon" flex-none h="1em" translate-y-1px />
     <button text-gray hover="underline" @click="searchFile">
       {{ filepath }}

--- a/app/components/RuleList.vue
+++ b/app/components/RuleList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Linter } from 'eslint'
 import type { RuleInfo } from '~~/shared/types'
-import { computed, defineComponent, Fragment, h } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { getRuleFromName, payload } from '~/composables/payload'
 import { isGridView } from '../composables/state'
 
@@ -38,8 +38,8 @@ const containerClass = computed(() => {
 const Wrapper = defineComponent({
   setup(_, { slots }) {
     return () => isGridView.value
-      ? h('div', { class: 'relative border border-base max-w-full rounded-lg p4 py3 flex flex-col gap-2 of-hidden justify-start' }, slots.default?.())
-      : h(Fragment, slots.default?.())
+      ? h('div', { 'class': 'relative border border-base max-w-full rounded-lg p4 py3 flex flex-col gap-2 of-hidden justify-start', 'data-testid': 'rule-item' }, slots.default?.())
+      : h('div', { 'class': 'contents', 'data-testid': 'rule-item' }, slots.default?.())
   },
 })
 </script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,3 +22,11 @@ export default await nuxt()
       'no-console': 'off',
     },
   })
+  .append({
+    ignores: [
+      'tests/e2e/fixtures/**',
+      'tests/e2e/.output/**',
+      'playwright-report/**',
+      'test-results/**',
+    ],
+  })

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "prepack": "pnpm build",
     "lint": "nuxt prepare && eslint .",
     "test": "vitest",
+    "pretest:e2e": "node -e \"process.exit(require('node:fs').existsSync('dist/cli.mjs')?0:1)\" || pnpm build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "typecheck": "nuxt typecheck"
   },
   "peerDependencies": {
@@ -60,6 +63,7 @@
     "@iconify-json/vscode-icons": "catalog:",
     "@nodelib/fs.walk": "catalog:",
     "@nuxt/eslint": "catalog:",
+    "@playwright/test": "catalog:",
     "@shikijs/langs-precompiled": "catalog:",
     "@shikijs/transformers": "catalog:",
     "@typescript-eslint/utils": "catalog:",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,61 @@
+import process from 'node:process'
+import { defineConfig } from '@playwright/test'
+
+const FIXTURE = 'tests/e2e/fixtures/basic'
+const DEV_PORT = 17780
+const BUILD_PORT = 17790
+const BUILD_OUT = 'tests/e2e/.output/build'
+
+/**
+ * Build-mode tests are opt-in via `E2E_INCLUDE_BUILD=1`. `devframe@0.1.22`'s
+ * static build adapter ships its bundled hash module with `ohash`'s Node
+ * entry, and unenv (Nuxt's client node-compat layer) does not implement
+ * `createHash`, so the built SPA crashes at runtime with
+ * "crypto.createHash is not implemented yet!" before the payload loads.
+ * Drop this gate once the upstream issue resolves.
+ */
+const INCLUDE_BUILD = !!process.env.E2E_INCLUDE_BUILD
+
+export default defineConfig({
+  testDir: 'tests/e2e/specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    trace: 'on-first-retry',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'dev',
+      use: { baseURL: `http://127.0.0.1:${DEV_PORT}` },
+    },
+    ...(INCLUDE_BUILD
+      ? [{
+          name: 'build',
+          use: { baseURL: `http://127.0.0.1:${BUILD_PORT}` },
+        }]
+      : []),
+  ],
+  webServer: [
+    {
+      command: `node bin.mjs --config ${FIXTURE}/eslint.config.js --basePath ${FIXTURE} --no-open --port ${DEV_PORT}`,
+      url: `http://127.0.0.1:${DEV_PORT}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    ...(INCLUDE_BUILD
+      ? [{
+          command: `node bin.mjs build --config ${FIXTURE}/eslint.config.js --basePath ${FIXTURE} --outDir ${BUILD_OUT} --base / && npx serve ${BUILD_OUT} --single --listen ${BUILD_PORT} --no-clipboard`,
+          url: `http://127.0.0.1:${BUILD_PORT}`,
+          reuseExistingServer: !process.env.CI,
+          timeout: 180_000,
+          stdout: 'pipe' as const,
+          stderr: 'pipe' as const,
+        }]
+      : []),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     '@nuxt/eslint':
       specifier: ^1.15.2
       version: 1.15.2
+    '@playwright/test':
+      specifier: ^1.59.1
+      version: 1.59.1
     '@shikijs/langs-precompiled':
       specifier: ^4.0.2
       version: 4.0.2
@@ -206,6 +209,9 @@ importers:
       '@nuxt/eslint':
         specifier: 'catalog:'
         version: 1.15.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint@10.3.0(jiti@2.6.1))(magicast@0.5.2)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.4))
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
       '@shikijs/langs-precompiled':
         specifier: 'catalog:'
         version: 4.0.2
@@ -1812,6 +1818,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3896,6 +3907,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4990,6 +5006,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -7890,6 +7916,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -10164,6 +10194,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11745,6 +11778,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   '@iconify-json/vscode-icons': ^1.2.49
   '@nodelib/fs.walk': ^3.0.1
   '@nuxt/eslint': ^1.15.2
+  '@playwright/test': ^1.59.1
   '@shikijs/langs-precompiled': ^4.0.2
   '@shikijs/transformers': ^4.0.2
   '@typescript-eslint/utils': ^8.59.2

--- a/tests/e2e/fixtures/basic/eslint.config.js
+++ b/tests/e2e/fixtures/basic/eslint.config.js
@@ -1,0 +1,21 @@
+export default [
+  {
+    name: 'basic/all',
+    files: ['**/*.{js,ts}'],
+    rules: {
+      'no-unused-vars': 'error',
+      'no-console': 'warn',
+    },
+  },
+  {
+    name: 'basic/tests',
+    files: ['**/*.test.{js,ts}'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
+    name: 'basic/ignores',
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+]

--- a/tests/e2e/fixtures/basic/src/sample.test.ts
+++ b/tests/e2e/fixtures/basic/src/sample.test.ts
@@ -1,0 +1,4 @@
+import { add } from './sample'
+
+const result = add(1, 2)
+console.log(result)

--- a/tests/e2e/fixtures/basic/src/sample.ts
+++ b/tests/e2e/fixtures/basic/src/sample.ts
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b
+}

--- a/tests/e2e/specs/_helpers.ts
+++ b/tests/e2e/specs/_helpers.ts
@@ -1,0 +1,12 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/**
+ * Navigate to the inspector and wait until the payload has loaded
+ * (NavBar rendered, "Loading config..." gone).
+ */
+export async function gotoInspector(page: Page, path: string): Promise<void> {
+  await page.goto(path)
+  await expect(page.getByText('Loading config...')).toHaveCount(0)
+  await expect(page.getByText(/Composed with/)).toBeVisible()
+}

--- a/tests/e2e/specs/configs.spec.ts
+++ b/tests/e2e/specs/configs.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+import { gotoInspector } from './_helpers'
+
+test('lists fixture configs plus ESLint defaults', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  // 3 fixture items + 4 internal ESLint defaults = 7 total
+  await expect(page.getByTestId('config-item')).toHaveCount(7)
+})
+
+test('filters configs by filepath', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  await page.getByPlaceholder('Test matching with filepath...').fill('src/sample.ts')
+
+  await expect(page.getByText('Filepath', { exact: true })).toBeVisible()
+  await expect(page.getByText(/matched with/)).toBeVisible()
+})
+
+test('reports no match for an ignored filepath', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  await page.getByPlaceholder('Test matching with filepath...').fill('dist/bundle.js')
+  await expect(page.getByText('is not included or has been ignored')).toBeVisible()
+})
+
+test('expand all and collapse all toggle config item state', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+
+  await page.getByRole('button', { name: 'Collapse All' }).click()
+  await expect(page.locator('[data-testid="config-item"][open]')).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Expand All' }).click()
+  const total = await page.getByTestId('config-item').count()
+  await expect(page.locator('[data-testid="config-item"][open]')).toHaveCount(total)
+})

--- a/tests/e2e/specs/files.spec.ts
+++ b/tests/e2e/specs/files.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+import { gotoInspector } from './_helpers'
+
+test('shows matched fixture files in list view', async ({ page }) => {
+  await gotoInspector(page, '/files')
+
+  await expect(page.getByText(/Matched Local Files/).first()).toBeVisible()
+
+  await expect(page.getByRole('button', { name: 'src/sample.ts', exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'src/sample.test.ts', exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'eslint.config.js', exact: true })).toBeVisible()
+})
+
+test('toggles between list and group views', async ({ page }) => {
+  await gotoInspector(page, '/files')
+
+  // List view: top-level FileItems with file-item data-testid
+  const listCount = await page.getByTestId('file-item').count()
+  expect(listCount).toBeGreaterThan(0)
+
+  await page.getByRole('button', { name: 'File Groups' }).click()
+  await expect(page.getByText('Configs Specific to the Files').first()).toBeVisible()
+  await expect(page.getByText('Matched Globs').first()).toBeVisible()
+
+  await page.getByRole('button', { name: 'List' }).click()
+  await expect(page.getByTestId('file-item')).toHaveCount(listCount)
+})
+
+test('clicking a file navigates to configs page with filter applied', async ({ page }) => {
+  await gotoInspector(page, '/files')
+  await page.getByRole('button', { name: 'src/sample.test.ts', exact: true }).click()
+  await expect(page).toHaveURL(/\/configs/)
+  await expect(page.getByPlaceholder('Test matching with filepath...')).toHaveValue('src/sample.test.ts')
+})

--- a/tests/e2e/specs/rules.spec.ts
+++ b/tests/e2e/specs/rules.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { gotoInspector } from './_helpers'
+
+test('lists used rules from the fixture', async ({ page }) => {
+  await gotoInspector(page, '/rules')
+  // Fixture uses 2 rules (no-unused-vars, no-console); default filter is 'using'
+  await expect(page.getByTestId('rule-item')).toHaveCount(2)
+})
+
+test('search narrows rules to a single match', async ({ page }) => {
+  await gotoInspector(page, '/rules')
+  await expect(page.getByTestId('rule-item')).toHaveCount(2)
+
+  await page.getByPlaceholder('Search rules...').fill('console')
+  await expect.poll(async () => page.getByTestId('rule-item').count(), {
+    timeout: 5000,
+  }).toBe(1)
+
+  await page.getByPlaceholder('Search rules...').fill('')
+  await expect.poll(async () => page.getByTestId('rule-item').count()).toBe(2)
+})

--- a/tests/e2e/specs/smoke.spec.ts
+++ b/tests/e2e/specs/smoke.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+import { gotoInspector } from './_helpers'
+
+test('redirects root to /configs and loads payload without error', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveURL(/\/configs(\?|$)/)
+  await expect(page).toHaveTitle(/ESLint Config Inspector/)
+  await expect(page.getByText('Failed to load')).toHaveCount(0)
+  await expect(page.getByText('Loading config...')).toHaveCount(0)
+})
+
+test('shows the inspector badge and nav links', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  await expect(page.getByRole('link', { name: /ESLint Config Inspector/ }).first()).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Configs' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Rules' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Files' })).toBeVisible()
+})
+
+test('header reports composed config count', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  await expect(page.getByText(/config items, updated/)).toBeVisible()
+})
+
+test('navigates between Configs, Rules, and Files', async ({ page }) => {
+  await gotoInspector(page, '/configs')
+  await page.getByRole('link', { name: 'Rules' }).click()
+  await expect(page).toHaveURL(/\/rules/)
+  await page.getByRole('link', { name: 'Files' }).click()
+  await expect(page).toHaveURL(/\/files/)
+  await page.getByRole('link', { name: 'Configs' }).click()
+  await expect(page).toHaveURL(/\/configs/)
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e/**'],
+  },
+})


### PR DESCRIPTION
## Summary
- 13 Playwright tests covering page load, NavBar navigation, config/rule/file listing, filtering and view toggles, run against a minimal flat-config fixture under `tests/e2e/fixtures/basic`.
- New `dev` and `build` projects in `playwright.config.ts` each spin up their own `webServer` (`node bin.mjs` and `node bin.mjs build && npx serve`); a `vitest.config.ts` excludes the e2e directory from unit-test discovery; minimal `data-testid` additions to `ConfigItem`/`RuleItem`/`FileItem` for stable list counts.
- New ubuntu-only `e2e` job in CI runs `pnpm test:e2e` after the existing `test` job and uploads `playwright-report/` on failure.
- Build-mode project is gated behind `E2E_INCLUDE_BUILD=1` until the upstream `devframe@0.1.22` issue is fixed: its bundled hash module imports `createHash` from `node:crypto`, which unenv stubs as "not implemented" in the client, crashing the static SPA before the payload loads.

## Test plan
- [x] `pnpm test:e2e` — 13 dev tests pass locally in ~5s
- [x] `pnpm test` — existing 9 unit tests still pass
- [x] `pnpm typecheck` and `pnpm lint` — clean
- [ ] CI `e2e` job is green on this PR