### PR TITLE
fix: render compound (AND) globs as a single badge (#190)

### DIFF
--- a/app/components/ConfigItem.vue
+++ b/app/components/ConfigItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import type { FiltersConfigsPage, FlatConfigItem } from '~~/shared/types'
+import type { FiltersConfigsPage, FlatConfigItem, GlobEntry } from '~~/shared/types'
 import { computed, ref, watchEffect } from 'vue'
+import { isSameGlobEntry } from '~~/shared/configs'
 import { getRuleLevel, getRuleOptions } from '~~/shared/rules'
 import { useRouter } from '#app/composables/router'
 import { filtersRules, isGridView } from '~/composables/state'
@@ -11,12 +12,16 @@ const props = defineProps<{
   index: number
   filters?: FiltersConfigsPage
   active?: boolean
-  matchedGlobs?: string[]
+  matchedGlobs?: GlobEntry[]
 }>()
 
 const emit = defineEmits<{
   badgeClick: [string]
 }>()
+
+function isGlobActive(entry: GlobEntry): boolean {
+  return !!props.matchedGlobs?.some(g => isSameGlobEntry(g, entry))
+}
 
 /**
  * Fields that are considered metadata and not part of the config object.
@@ -129,9 +134,9 @@ const extraConfigs = computed(() => {
           <div>Applies to files matching</div>
           <div flex="~ gap-2 items-center wrap">
             <GlobItem
-              v-for="glob, idx of config.files?.flat()"
-              :key="idx" :glob="glob" popup="files"
-              :active="matchedGlobs?.includes(glob)"
+              v-for="entry, idx of config.files"
+              :key="idx" :glob="entry" popup="files"
+              :active="isGlobActive(entry)"
             />
           </div>
         </div>
@@ -168,9 +173,9 @@ const extraConfigs = computed(() => {
           </div>
           <div flex="~ gap-2 items-center wrap">
             <GlobItem
-              v-for="glob, idx of config.ignores"
-              :key="idx" :glob="glob"
-              :active="matchedGlobs?.includes(glob)"
+              v-for="entry, idx of config.ignores"
+              :key="idx" :glob="entry"
+              :active="isGlobActive(entry)"
             />
           </div>
         </div>

--- a/app/components/FileGroupItem.vue
+++ b/app/components/FileGroupItem.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
-import type { FilesGroup } from '~~/shared/types'
+import type { FilesGroup, GlobEntry } from '~~/shared/types'
 import { computed, ref, watchEffect } from 'vue'
+import { isSameGlobEntry } from '~~/shared/configs'
 import { useRouter } from '#app/composables/router'
 
 const props = defineProps<{
   index: number
   group: FilesGroup
 }>()
+
+function isEntryInGroup(entry: GlobEntry): boolean {
+  return props.group.globs.some(g => isSameGlobEntry(g, entry))
+}
 
 const open = defineModel('open', {
   default: true,
@@ -29,10 +34,10 @@ const groupName = computed(() => {
       config: props.group.configs[0]!,
     } as const
   }
-  if (props.group.globs.size <= 2) {
+  if (props.group.globs.length <= 2) {
     return {
       type: 'glob',
-      globs: [...props.group.globs.values()],
+      globs: props.group.globs,
     } as const
   }
   return undefined
@@ -138,10 +143,10 @@ function goToConfig(idx: number) {
                       </div>
                       <div flex="~ gap-2 items-center wrap">
                         <GlobItem
-                          v-for="glob, idx2 of config.files?.flat()"
+                          v-for="entry, idx2 of config.files"
                           :key="idx2"
-                          :glob="glob"
-                          :active="group.globs.has(glob)"
+                          :glob="entry"
+                          :active="isEntryInGroup(entry)"
                         />
                       </div>
                     </div>

--- a/app/components/GlobItem.vue
+++ b/app/components/GlobItem.vue
@@ -1,31 +1,70 @@
 <script setup lang="ts">
+import type { FlatConfigItem, GlobEntry } from '~~/shared/types'
 import { Dropdown as VDropdown } from 'floating-vue'
 import { computed, defineComponent } from 'vue'
 import { useRouter } from '#app/composables/router'
 import { payload } from '~/composables/payload'
 import { filtersConfigs } from '~/composables/state'
-import { useHighlightedGlob } from '../composables/shiki'
+import { isDark } from '../composables/dark'
+import { sanitizeHtml, shiki } from '../composables/shiki'
 
 const props = withDefaults(
   defineProps<{
-    glob: string
+    glob: GlobEntry
     popup?: 'files' | 'configs'
     active?: boolean | null
   }>(),
   { active: null },
 )
 
-const highlighted = useHighlightedGlob(() => props.glob.toString())
+const patterns = computed(() => Array.isArray(props.glob) ? props.glob : [props.glob])
+const isCompound = computed(() => patterns.value.length > 1)
+
+function highlight(code: string): string {
+  if (!shiki.value)
+    return sanitizeHtml(code)
+  return shiki.value.codeToHtml(code, {
+    lang: 'glob',
+    theme: isDark.value ? 'vitesse-dark' : 'vitesse-light',
+    structure: 'inline',
+  })
+}
+
+const highlightedPatterns = computed(() => patterns.value.map(highlight))
 
 const showsPopup = computed(() => (props.popup === 'files' && payload.value.filesResolved) || props.popup === 'configs')
-const files = computed(() => props.popup === 'files'
-  ? payload.value.filesResolved?.globToFiles.get(props.glob)
-  : undefined)
 
-const configs = computed(() => props.popup === 'configs'
-  ? payload.value.globToConfigs.get(props.glob)
-  : undefined,
-)
+const files = computed<Set<string> | undefined>(() => {
+  if (props.popup !== 'files')
+    return undefined
+  const globToFiles = payload.value.filesResolved?.globToFiles
+  if (!globToFiles)
+    return undefined
+  // For a compound (AND) entry, the matching files are the intersection of
+  // each pattern's matches.
+  const sets = patterns.value.map(p => globToFiles.get(p))
+  if (sets.length === 0 || sets.some(s => !s))
+    return new Set()
+  const resolved = sets as Set<string>[]
+  if (resolved.length === 1)
+    return resolved[0]
+  const first = resolved[0]!
+  return new Set([...first].filter(f => resolved.slice(1).every(s => s.has(f))))
+})
+
+const configs = computed<FlatConfigItem[] | undefined>(() => {
+  if (props.popup !== 'configs')
+    return undefined
+  if (isCompound.value) {
+    return payload.value.configs.filter((c) => {
+      if (!c.files)
+        return false
+      const flat = c.files.flat()
+      return patterns.value.every(p => flat.includes(p))
+    })
+  }
+  return payload.value.globToConfigs.get(patterns.value[0]!)
+})
 
 const router = useRouter()
 function goToConfig(idx: number) {
@@ -43,10 +82,16 @@ const Noop = defineComponent({ setup: (_, { slots }) => () => slots.default?.() 
       text-gray font-mono
       :class="active === true ? 'badge-active' : active === false ? 'badge op50' : 'badge'"
     >
-      <span class="filter-hue-rotate-180" v-html="highlighted" />
+      <template v-for="html, i of highlightedPatterns" :key="i">
+        <span v-if="i > 0" mx1 op50>&amp;</span>
+        <span class="filter-hue-rotate-180" v-html="html" />
+      </template>
     </component>
     <template #popper="{ shown, hide }">
       <div v-if="shown && popup === 'files'" max-h="30vh" min-w-80 of-auto p3>
+        <div v-if="isCompound" mb2 text-xs op60>
+          Compound glob (intersection of {{ patterns.length }} patterns)
+        </div>
         <div v-if="files?.size" flex="~ col gap-1">
           <div>Files that matches this glob</div>
           <FileItem
@@ -62,6 +107,9 @@ const Noop = defineComponent({ setup: (_, { slots }) => () => slots.default?.() 
       </div>
 
       <div v-if="shown && popup === 'configs'" max-h="30vh" min-w-80 of-auto p3>
+        <div v-if="isCompound" mb2 text-xs op60>
+          Compound glob (intersection of {{ patterns.length }} patterns)
+        </div>
         <div v-if="configs?.length" flex="~ col gap-1">
           <div>Configs that contains this glob</div>
           <div v-for="config of configs" :key="config.name" flex="~ gap-2">

--- a/app/components/RuleStateItem.vue
+++ b/app/components/RuleStateItem.vue
@@ -71,7 +71,7 @@ function goto() {
             Applies to files matching
           </div>
           <div flex="~ gap-2 items-center wrap">
-            <GlobItem v-for="glob, idx of config.files?.flat()" :key="idx" :glob="glob" />
+            <GlobItem v-for="entry, idx of config.files" :key="idx" :glob="entry" />
           </div>
         </div>
       </template>

--- a/app/composables/payload.ts
+++ b/app/composables/payload.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import type { ErrorInfo, FilesGroup, FlatConfigItem, Payload, ResolvedPayload, RuleConfigStates, RuleInfo } from '~~/shared/types'
+import type { ErrorInfo, FilesGroup, FlatConfigItem, GlobEntry, Payload, ResolvedPayload, RuleConfigStates, RuleInfo } from '~~/shared/types'
 import { defineRpcFunction } from 'devframe'
 import { connectDevframe } from 'devframe/client'
 import { computed, ref } from 'vue'
@@ -114,7 +114,10 @@ export function resolvePayload(payload: Payload): ResolvedPayload {
       })
     }
 
-    // Globs
+    // Globs — `globToConfigs` is a per-pattern reverse-lookup map.
+    // Compound (intersection) entries from `config.files` are split into
+    // their constituent patterns here; compound badges in the UI compute
+    // their own intersection from `globToFiles` instead of reading this map.
     for (const glob of config.files?.flat() || []) {
       if (!globToConfigs.has(glob))
         globToConfigs.set(glob, [])
@@ -142,6 +145,10 @@ export function resolvePayload(payload: Payload): ResolvedPayload {
   }
 }
 
+function globEntryKey(g: GlobEntry): string {
+  return Array.isArray(g) ? `[${g.join('\x00')}]` : g
+}
+
 function resolveFiles(payload: Payload): ResolvedPayload['filesResolved'] {
   if (!payload.files)
     return undefined
@@ -155,16 +162,25 @@ function resolveFiles(payload: Payload): ResolvedPayload['filesResolved'] {
   const fileToConfigs = new Map<string, Set<number>>()
   const configToFiles = new Map<number, Set<string>>()
   const filesGroupMap = new Map<string, FilesGroup>()
+  // Track per-group glob entries by their key so compound entries can be
+  // deduplicated while preserving their AND grouping for display.
+  const groupGlobKeys = new Map<string, Set<string>>()
 
   for (const file of payload.files) {
     files.push(file.filepath)
-    for (const glob of file.globs) {
-      if (!globToFiles.has(glob))
-        globToFiles.set(glob, new Set())
-      globToFiles.get(glob)!.add(file.filepath)
-      if (!fileToGlobs.has(file.filepath))
-        fileToGlobs.set(file.filepath, new Set())
-      fileToGlobs.get(file.filepath)!.add(glob)
+    for (const entry of file.globs) {
+      // Per-pattern lookups (compound entries are expanded to their members,
+      // which are guaranteed to have matched the file since the intersection
+      // matched).
+      const patterns = Array.isArray(entry) ? entry : [entry]
+      for (const p of patterns) {
+        if (!globToFiles.has(p))
+          globToFiles.set(p, new Set())
+        globToFiles.get(p)!.add(file.filepath)
+        if (!fileToGlobs.has(file.filepath))
+          fileToGlobs.set(file.filepath, new Set())
+        fileToGlobs.get(file.filepath)!.add(p)
+      }
     }
     for (const configIndex of file.configs) {
       if (!configToFiles.has(configIndex))
@@ -182,12 +198,20 @@ function resolveFiles(payload: Payload): ResolvedPayload['filesResolved'] {
         id: groupId,
         files: [],
         configs: specialConfigs.map(i => payload.configs[i]!),
-        globs: new Set<string>(),
+        globs: [],
       })
+      groupGlobKeys.set(groupId, new Set())
     }
     const group = filesGroupMap.get(groupId)!
+    const seenKeys = groupGlobKeys.get(groupId)!
     group.files.push(file.filepath)
-    file.globs.forEach(i => group.globs.add(i))
+    for (const entry of file.globs) {
+      const k = globEntryKey(entry)
+      if (!seenKeys.has(k)) {
+        seenKeys.add(k)
+        group.globs.push(entry)
+      }
+    }
   }
 
   const groups = Array.from(filesGroupMap.values())

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,9 +2,13 @@ import process from 'node:process'
 import { defineConfig } from '@playwright/test'
 
 const FIXTURE = 'tests/e2e/fixtures/basic'
+const EXTENDS_FIXTURE = 'tests/e2e/fixtures/extends'
 const DEV_PORT = 17780
+const EXTENDS_DEV_PORT = 17781
 const BUILD_PORT = 17790
 const BUILD_OUT = 'tests/e2e/.output/build'
+
+export const EXTENDS_BASE_URL = `http://127.0.0.1:${EXTENDS_DEV_PORT}`
 
 /**
  * Build-mode tests are opt-in via `E2E_INCLUDE_BUILD=1`. `devframe@0.1.22`'s
@@ -42,6 +46,14 @@ export default defineConfig({
     {
       command: `node bin.mjs --config ${FIXTURE}/eslint.config.js --basePath ${FIXTURE} --no-open --port ${DEV_PORT}`,
       url: `http://127.0.0.1:${DEV_PORT}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: `node bin.mjs --config ${EXTENDS_FIXTURE}/eslint.config.js --basePath ${EXTENDS_FIXTURE} --no-open --port ${EXTENDS_DEV_PORT}`,
+      url: `http://127.0.0.1:${EXTENDS_DEV_PORT}`,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       stdout: 'pipe',

--- a/shared/configs.ts
+++ b/shared/configs.ts
@@ -17,9 +17,35 @@ function minimatch(file: string, pattern: string) {
   return m.match(file)
 }
 
-export function getMatchedGlobs(file: string, glob: (string | string[])[]) {
-  const globs = (Array.isArray(glob) ? glob : [glob]).flat()
-  return globs.filter(glob => minimatch(file, glob)).flat()
+/**
+ * Returns the entries from `globs` that match `file`.
+ *
+ * An entry is either a string pattern (matches when the file matches that pattern)
+ * or an array of string patterns representing an intersection — i.e. the file
+ * must match every pattern in the inner array. This mirrors ESLint's flat-config
+ * semantics in `@eslint/config-array`'s `pathMatches`.
+ */
+export function getMatchedGlobs(file: string, globs: (string | string[])[]): (string | string[])[] {
+  return globs.filter(g =>
+    Array.isArray(g)
+      ? g.every(p => minimatch(file, p))
+      : minimatch(file, g),
+  )
+}
+
+/**
+ * Structural equality for a single glob entry (string or `string[]`).
+ */
+export function isSameGlobEntry(a: string | string[], b: string | string[]): boolean {
+  if (Array.isArray(a) !== Array.isArray(b))
+    return false
+  if (Array.isArray(a))
+    return a.length === (b as string[]).length && a.every((x, i) => x === (b as string[])[i])
+  return a === b
+}
+
+function globEntryKey(g: string | string[]): string {
+  return Array.isArray(g) ? `[${g.join('\x00')}]` : g
 }
 
 const META_KEYS = new Set(['name', 'index'])
@@ -67,7 +93,14 @@ export function matchFile(
     result.globs.push(...negative)
   })
 
-  result.globs = [...new Set(result.globs)]
+  const seen = new Set<string>()
+  result.globs = result.globs.filter((g) => {
+    const k = globEntryKey(g)
+    if (seen.has(k))
+      return false
+    seen.add(k)
+    return true
+  })
 
   return result
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,6 +5,8 @@ export interface FlatConfigItem extends Linter.Config {
   index: number
 }
 
+export type GlobEntry = string | string[]
+
 export type RuleLevel = 'off' | 'warn' | 'error'
 
 export interface Payload {
@@ -41,9 +43,12 @@ export interface MatchedFile {
    */
   filepath: string
   /**
-   * Matched globs, includes both positive and negative globs
+   * Matched globs, includes both positive and negative globs.
+   *
+   * A string entry is a single pattern; an array entry is an intersection
+   * (all inner patterns must match), matching ESLint's flat-config semantics.
    */
-  globs: string[]
+  globs: GlobEntry[]
   /**
    * Matched configs indexes
    */
@@ -59,7 +64,11 @@ export interface FilesGroup {
   id: string
   files: string[]
   configs: FlatConfigItem[]
-  globs: Set<string>
+  /**
+   * Deduplicated list of glob entries that matched any file in this group.
+   * A `string[]` entry represents an intersection (AND).
+   */
+  globs: GlobEntry[]
 }
 
 export interface PayloadMeta {

--- a/tests/e2e/fixtures/extends/eslint.config.js
+++ b/tests/e2e/fixtures/extends/eslint.config.js
@@ -1,0 +1,12 @@
+import js from '@eslint/js'
+import { defineConfig } from 'eslint/config'
+
+export default defineConfig(js.configs.recommended, {
+  files: ['root.js'],
+  extends: [
+    {
+      files: ['subdir/*.js'],
+      rules: { 'no-unused-vars': 'off' },
+    },
+  ],
+})

--- a/tests/e2e/fixtures/extends/root.js
+++ b/tests/e2e/fixtures/extends/root.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b
+}

--- a/tests/e2e/fixtures/extends/subdir/file.js
+++ b/tests/e2e/fixtures/extends/subdir/file.js
@@ -1,0 +1,3 @@
+export function sub(a, b) {
+  return a - b
+}

--- a/tests/e2e/specs/extends.spec.ts
+++ b/tests/e2e/specs/extends.spec.ts
@@ -1,0 +1,33 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { EXTENDS_BASE_URL } from '../../../playwright.config'
+
+async function gotoExtends(page: Page, path: string) {
+  await page.goto(`${EXTENDS_BASE_URL}${path}`)
+  await expect(page.getByText('Loading config...')).toHaveCount(0)
+  await expect(page.getByText(/Composed with/)).toBeVisible()
+}
+
+test('renders a compound (AND) glob as a single badge with `&` separator', async ({ page }) => {
+  await gotoExtends(page, '/configs')
+
+  // The config produced by `defineConfig` for the extended item has
+  // files: [['root.js', 'subdir/*.js']] — a single compound (AND) entry.
+  // It must render as one badge with both patterns joined by `&`, not as
+  // two independent badges (which would falsely imply OR).
+  const extendedConfig = page
+    .getByTestId('config-item')
+    .filter({ hasText: 'ExtendedConfig' })
+    .first()
+
+  await expect(extendedConfig).toBeVisible()
+
+  const filesRow = extendedConfig
+    .locator('text=Applies to files matching')
+    .locator('xpath=..')
+
+  const filesText = (await filesRow.textContent()) ?? ''
+  expect(filesText).toContain('root.js')
+  expect(filesText).toContain('subdir/*.js')
+  expect(filesText).toContain('&')
+})

--- a/tests/shared_configs.test.ts
+++ b/tests/shared_configs.test.ts
@@ -95,4 +95,55 @@ describe('matchFile', () => {
       expect(result.configs).toEqual([0, 3, 4, 7])
     })
   })
+
+  describe('compound globs (AND)', () => {
+    it('should not match when intersection is empty (issue #190)', () => {
+      // mirrors `defineConfig({ files: ['root.js'], extends: [{ files: ['subdir/*.js'], ... }] })`
+      const result = matchFile('root.js', [
+        { index: 0, files: [['root.js', 'subdir/*.js']], rules: { 'no-unused-vars': 'off' } },
+        { index: 1, files: ['root.js'] },
+      ], process.cwd())
+      expect(result.configs).toEqual([1])
+    })
+
+    it('should not match when one inner pattern fails', () => {
+      const result = matchFile('src/a.ts', [
+        { index: 0, files: [['src/**', '*.js']] },
+      ], process.cwd())
+      expect(result.configs).toEqual([])
+    })
+
+    it('should match when every inner pattern matches', () => {
+      const result = matchFile('src/a.ts', [
+        { index: 0, files: [['src/**', '**/*.ts']] },
+      ], process.cwd())
+      expect(result.configs).toEqual([0])
+      expect(result.globs).toEqual([['src/**', '**/*.ts']])
+    })
+
+    it('should mix single and compound entries (OR over outer, AND over inner)', () => {
+      const configs = [
+        { index: 0, files: ['a.js', ['b.js', '**/*.ts']] },
+      ]
+      const a = matchFile('a.js', configs, process.cwd())
+      expect(a.configs).toEqual([0])
+      expect(a.globs).toEqual(['a.js'])
+
+      const b = matchFile('b.ts', configs, process.cwd())
+      // 'b.ts' matches the compound ['b.js', '**/*.ts']? No — 'b.ts' doesn't match 'b.js'.
+      expect(b.configs).toEqual([])
+
+      const c = matchFile('b.js', configs, process.cwd())
+      // 'b.js' matches 'b.js' but not '**/*.ts'.
+      expect(c.configs).toEqual([])
+    })
+
+    it('should match a compound where every pattern fits', () => {
+      const result = matchFile('src/foo.ts', [
+        { index: 0, files: ['a.js', ['src/**', '**/*.ts']] },
+      ], process.cwd())
+      expect(result.configs).toEqual([0])
+      expect(result.globs).toEqual([['src/**', '**/*.ts']])
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Fixes [#190](https://github.com/eslint/config-inspector/issues/190): `defineConfig` with `extends` produces `files` as an array-of-arrays where inner arrays represent intersection (AND), but the inspector flattened them with `.flat()` and rendered two independent badges — misleading users to read it as OR.
- `getMatchedGlobs` now honors AND/OR semantics (mirroring `@eslint/config-array`'s `pathMatches`); `GlobItem.vue` accepts `string | string[]` and renders compound entries as one badge joining patterns with `&`, with popups computing the intersection from `globToFiles`.
- New vitest cases cover compound matching; a new e2e fixture replays the exact config from the issue and asserts the badge renders with both patterns and `&`.

## Test plan

- [x] \`pnpm test\` — 14 passed (10 original + 4 new compound cases)
- [x] \`pnpm exec playwright test\` — 14 passed (13 original + 1 new extends spec)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean