### PR TITLE
feat: render ` > ` between extended config names as a chevron

### DIFF
--- a/app/components/ColorizedConfigName.ts
+++ b/app/components/ColorizedConfigName.ts
@@ -11,18 +11,32 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const parts = computed(() => props.name?.split(/([:/])/g).filter(Boolean))
+    const groups = computed(() =>
+      props.name?.split(' > ').map(g => g.split(/([:/])/g).filter(Boolean)),
+    )
     return () => {
-      if (parts.value) {
-        return h('span', parts.value.map((part, i) => h(
-          'span',
-          [':', '/'].includes(part)
-            ? { style: { opacity: 0.35, margin: '0 1px' } }
-            : i !== parts.value!.length - 1
-              ? { style: { color: getPluginColor(part) } }
-              : null,
-          part,
-        )))
+      if (groups.value) {
+        const children: any[] = []
+        groups.value.forEach((parts, gi) => {
+          if (gi > 0) {
+            children.push(h('span', {
+              class: 'i-ph-caret-right inline-block op35',
+              style: { margin: '0 0.25em', verticalAlign: '-0.1em' },
+            }))
+          }
+          parts.forEach((part, i) => {
+            children.push(h(
+              'span',
+              [':', '/'].includes(part)
+                ? { style: { opacity: 0.35, margin: '0 1px' } }
+                : i !== parts.length - 1
+                  ? { style: { color: getPluginColor(part) } }
+                  : null,
+              part,
+            ))
+          })
+        })
+        return h('span', children)
       }
       else {
         return h('span', [


### PR DESCRIPTION
## Summary

- `defineConfig` from `eslint/config` joins extended config names with ` > ` (e.g. `UserConfig[1] > ExtendedConfig[0]`). The previous `ColorizedConfigName` segmentation only split on `:` and `/`, so the ` > ` was buried inside one segment and the parent's final token was mis-tinted as non-final.
- The name is now split on ` > ` first, the existing `:`/`/` coloring is applied per group, and a Phosphor `i-ph-caret-right` chevron is rendered between groups.

## Test plan

- [x] `pnpm lint` and `pnpm typecheck` pass
- [x] `pnpm exec playwright test tests/e2e/specs/extends.spec.ts` passes
- [x] Live DOM check against `tests/e2e/fixtures/extends`: `UserConfig[1] > ExtendedConfig[0]` renders as two text spans with the chevron icon between them; plain names like `eslint/defaults/languages` still render with the original `:`/`/` coloring