### PR TITLE
fix: await Promise-like default exports

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -132,7 +132,12 @@ export async function readConfig(
 
   const dependencies = collectJitiDependencies(jiti, configPath)
 
-  const exported = ((mod as any)?.default ?? mod) as FlatConfigItem | FlatConfigItem[]
+  // `await` is required for Promise-like default exports such as
+  // `eslint-flat-config-utils`' `FlatConfigComposer` (used by `@antfu/eslint-config`
+  // and others), which extends `Promise` and only yields the real config array
+  // once awaited. Awaiting a non-thenable resolves to the value itself, so plain
+  // array/object exports are unaffected.
+  const exported = await ((mod as any)?.default ?? mod) as FlatConfigItem | FlatConfigItem[]
 
   // A single flat config object is also valid. Always clone into a fresh
   // array so the ESLint defaults `unshift`ed below don't mutate the user's

--- a/tests/fixtures/composer/eslint.config.js
+++ b/tests/fixtures/composer/eslint.config.js
@@ -1,0 +1,23 @@
+// Mirrors `eslint-flat-config-utils`' FlatConfigComposer surface enough to
+// exercise the inspector's Promise-resolving loader: extends `Promise`,
+// carries an own `_operations` field that would trip ConfigArray's schema
+// validation if left unresolved, and resolves to the actual config array.
+class MiniComposer extends Promise {
+  _operations = []
+
+  constructor() {
+    super(() => {})
+  }
+
+  then(onFulfilled, onRejected) {
+    return Promise.resolve([
+      {
+        name: 'composer/all',
+        files: ['**/*.js'],
+        rules: { 'no-console': 'warn' },
+      },
+    ]).then(onFulfilled, onRejected)
+  }
+}
+
+export default new MiniComposer()

--- a/tests/read_config.test.ts
+++ b/tests/read_config.test.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { readConfig } from '../src/configs'
+
+const fixturesDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures')
+
+describe('readConfig', () => {
+  it('resolves a Promise-like default export (e.g. FlatConfigComposer)', async () => {
+    const cwd = resolve(fixturesDir, 'composer')
+
+    const result = await readConfig({
+      cwd,
+      userConfigPath: 'eslint.config.js',
+      chdir: false,
+    })
+
+    const userConfig = result.configs.find(c => c.name === 'composer/all')
+    expect(userConfig, 'composer fixture should be unwrapped into its config array').toBeDefined()
+
+    for (const config of result.configs)
+      expect(Object.keys(config)).not.toContain('_operations')
+  })
+})


### PR DESCRIPTION
## Summary

- `eslint-flat-config-utils`' `FlatConfigComposer` (used by `@antfu/eslint-config` and others) extends `Promise`, so reading `mod.default` without `await` left the composer instance — carrying its own `_operations` field — in the configs array as a single object, which `ConfigArray.getConfigWithStatus` later rejected with `Unexpected key "_operations" found`.
- ESLint's CLI avoids this because its `loadConfigFile` returns through an async function whose Promise adopts the thenable; the inspector extracted `.default` directly, so the adoption never happened. Awaiting it now triggers the same adoption and is a no-op for plain array/object exports.
- Adds a `MiniComposer` fixture and a Vitest regression test (`tests/read_config.test.ts`) that reproduces the exact `_operations` error without the fix.

## Test plan

- [x] `pnpm test` — 15/15 pass (incl. new regression test)
- [x] Confirmed regression test fails on `main` with the same `Unexpected key "_operations" found` from the bug report
- [x] `pnpm test:e2e` — 14/14 Playwright tests pass (plain-array fixtures unaffected)
- [x] Manual: `node bin.mjs build` against `@antfu/eslint-config` loads 73 config items / 1770 rules (previously crashed)