### PR TITLE
fix: add Playwright contrast tests and improve light/dark contrast

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -14,15 +14,15 @@ init(config.app.baseURL)
   <div v-if="errorInfo" grid h-full w-full place-content-center whitespace-pre-line p4>
     <ConfigInspectorBadge mb6 text-xl font-200 />
 
-    <div text-2xl text-red5 font-bold>
-      Failed to load <span rounded bg-red:5 px2>eslint.config.js</span><br>
+    <div text-2xl text-rose-700 font-bold dark:text-rose-300>
+      Failed to load <span rounded bg-rose-50 px2 dark:bg-rose-900:20>eslint.config.js</span><br>
     </div>
 
-    <div text-lg text-red font-mono>
+    <div text-lg text-rose-700 font-mono dark:text-rose-300>
       {{ errorInfo.error }}
     </div>
 
-    <div mt6 op50>
+    <div mt6 color-muted>
       Note that
       <a href="https://github.com/eslint/config-inspector" target="_blank" hover:underline>config inspector</a>
       only works with the <a href="https://eslint.org/docs/latest/use/configure/configuration-files-new" target="_blank" font-bold hover:underline>flat config format</a>.

--- a/app/components/ColorizedConfigName.ts
+++ b/app/components/ColorizedConfigName.ts
@@ -20,7 +20,7 @@ export default defineComponent({
         groups.value.forEach((parts, gi) => {
           if (gi > 0) {
             children.push(h('span', {
-              class: 'i-ph-caret-right inline-block op35',
+              class: 'i-ph-caret-right inline-block color-faint',
               style: { margin: '0 0.25em', verticalAlign: '-0.1em' },
             }))
           }
@@ -28,7 +28,7 @@ export default defineComponent({
             children.push(h(
               'span',
               [':', '/'].includes(part)
-                ? { style: { opacity: 0.35, margin: '0 1px' } }
+                ? { class: 'color-faint', style: { margin: '0 1px' } }
                 : i !== parts.length - 1
                   ? { style: { color: getPluginColor(part) } }
                   : null,
@@ -40,9 +40,9 @@ export default defineComponent({
       }
       else {
         return h('span', [
-          h('span', { class: 'op50 italic' }, 'anonymous'),
+          h('span', { class: 'color-muted italic' }, 'anonymous'),
           props.index != null
-            ? h('span', { class: 'op50 text-sm' }, ` #${props.index + 1}`)
+            ? h('span', { class: 'color-muted text-sm' }, ` #${props.index + 1}`)
             : null,
         ])
       }

--- a/app/components/ColorizedRuleName.vue
+++ b/app/components/ColorizedRuleName.vue
@@ -53,8 +53,8 @@ const parsed = computed(() => {
     ]"
   >
     <span v-if="parsed.scope" :style="{ color: getPluginColor(parsed.scope) }">{{ parsed.scope }}</span>
-    <span v-if="parsed.scope" op30>/</span>
+    <span v-if="parsed.scope" color-faint>/</span>
     <br v-if="parsed.scope && props.break">
-    <span op75>{{ parsed.name }}</span>
+    <span color-base>{{ parsed.name }}</span>
   </component>
 </template>

--- a/app/components/ConfigInspectorBadge.vue
+++ b/app/components/ConfigInspectorBadge.vue
@@ -21,7 +21,7 @@ withDefaults(
     </a>
     <a
       v-if="showVersion"
-      ml1 inline-block translate-y--5 text-0.6em font-200 font-mono op50
+      ml1 inline-block translate-y--5 text-0.6em color-muted font-200 font-mono
       :href="`https://github.com/eslint/config-inspector/releases/tag/v${version}`" target="_blank"
     >
       v{{ version }}

--- a/app/components/ConfigItem.vue
+++ b/app/components/ConfigItem.vue
@@ -75,13 +75,13 @@ const extraConfigs = computed(() => {
     @toggle="open = ($event.target as any).open"
   >
     <summary block>
-      <div class="absolute right-[calc(100%+10px)] top-1.5" text-right font-mono op35 lt-lg:hidden>
+      <div class="absolute right-[calc(100%+10px)] top-1.5" text-right color-muted font-mono lt-lg:hidden>
         #{{ index + 1 }}
       </div>
       <div flex="~ gap-2 items-center" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono>
-        <div class="[details[open]_&]:rotate-90" i-ph-caret-right flex-none op50 transition />
+        <div class="[details[open]_&]:rotate-90" i-ph-caret-right flex-none color-muted transition />
         <div flex flex-auto flex-col flex-wrap gap-3 md:flex-row md:justify-end>
-          <span :class="config.name ? '' : 'op50 italic'" flex-1>
+          <span :class="config.name ? '' : 'color-muted italic'" flex-1>
             <ColorizedConfigName v-if="config.name" :name="config.name" />
             <span v-else>anonymous #{{ index + 1 }}</span>
           </span>
@@ -123,7 +123,10 @@ const extraConfigs = computed(() => {
       </div>
     </summary>
 
-    <div pointer-events-none absolute right-2 top-2 text-right text-5em font-mono op5>
+    <div
+      aria-hidden="true" data-a11y-skip
+      pointer-events-none absolute right-2 top-2 text-right text-5em font-mono op5
+    >
       #{{ index + 1 }}
     </div>
 
@@ -190,7 +193,7 @@ const extraConfigs = computed(() => {
           :class="isGridView ? 'pl6' : ''"
           :rules="config.rules"
           :filter="name => !filters?.rule || filters.rule === name"
-          :get-bind="(name: string) => ({ class: getRuleLevel(config.rules?.[name]) === 'off' ? 'op50' : '' })"
+          :get-bind="(name: string) => ({ class: getRuleLevel(config.rules?.[name]) === 'off' ? 'color-muted' : '' })"
         >
           <template #popup="{ ruleName, value }">
             <RuleStateItem
@@ -216,7 +219,7 @@ const extraConfigs = computed(() => {
           </template>
         </RuleList>
         <div>
-          <button v-if="filters?.rule" ml8 op50 @click="emit('badgeClick', '')">
+          <button v-if="filters?.rule" ml8 color-muted @click="emit('badgeClick', '')">
             ...{{ Object.keys(config.rules).filter(r => r !== filters?.rule).length }} others rules are hidden
           </button>
         </div>
@@ -230,7 +233,7 @@ const extraConfigs = computed(() => {
           </div>
           <template v-for="v, k in extraConfigs" :key="k">
             <div border="~ base rounded-lg">
-              <div of-auto p2 px3 op50>
+              <div of-auto p2 px3 color-muted>
                 {{ k }}
               </div>
               <Shiki

--- a/app/components/FileGroupItem.vue
+++ b/app/components/FileGroupItem.vue
@@ -58,15 +58,15 @@ function goToConfig(idx: number) {
     @toggle="open = $event.target.open"
   >
     <summary block>
-      <div class="absolute right-[calc(100%+10px)] top-1.5" text-right font-mono op35 lt-lg:hidden>
+      <div class="absolute right-[calc(100%+10px)] top-1.5" text-right color-muted font-mono lt-lg:hidden>
         #{{ index + 1 }}
       </div>
       <div flex="~ gap-2 items-start wrap items-center" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono>
-        <div class="[details[open]_&]:rotate-90" i-ph-caret-right op50 transition />
+        <div class="[details[open]_&]:rotate-90" i-ph-caret-right color-muted transition />
         <div flex flex-auto flex-col gap-3 md:flex-row>
           <span flex-auto flex="~ gap-2 items-center">
             <template v-if="groupName?.type === 'config'">
-              <span op75>Config</span>
+              <span color-muted>Config</span>
               <ColorizedConfigName
                 badge
                 :name="groupName.config.name"
@@ -74,14 +74,14 @@ function goToConfig(idx: number) {
               />
             </template>
             <template v-else-if="groupName?.type === 'glob'">
-              <span op75>Globs</span>
+              <span color-muted>Globs</span>
               <GlobItem
                 v-for="glob, idx of groupName.globs"
                 :key="idx"
                 :glob="glob"
               />
             </template>
-            <span v-else op50>
+            <span v-else color-muted>
               Files group #{{ index + 1 }}
             </span>
           </span>
@@ -105,7 +105,10 @@ function goToConfig(idx: number) {
       </div>
     </summary>
 
-    <div pointer-events-none absolute right-2 top-2 text-right text-5em font-mono op5>
+    <div
+      aria-hidden="true" data-a11y-skip
+      pointer-events-none absolute right-2 top-2 text-right text-5em font-mono op5
+    >
       #{{ index + 1 }}
     </div>
 
@@ -136,9 +139,9 @@ function goToConfig(idx: number) {
                 </div>
                 <div p3 border="t base">
                   <div flex="~ gap-2 items-start">
-                    <div i-ph-file-magnifying-glass-duotone my1 flex-none op75 />
+                    <div i-ph-file-magnifying-glass-duotone my1 flex-none color-muted />
                     <div flex="~ col gap-2">
-                      <div op50>
+                      <div color-muted>
                         Applies to files matching
                       </div>
                       <div flex="~ gap-2 items-center wrap">

--- a/app/components/FileItem.vue
+++ b/app/components/FileItem.vue
@@ -27,7 +27,7 @@ function searchFile() {
 <template>
   <div flex="~ gap-2 items-center" data-testid="file-item">
     <div :class="icon" flex-none h="1em" translate-y-1px />
-    <button text-gray hover="underline" @click="searchFile">
+    <button color-muted hover="color-base underline" @click="searchFile">
       {{ filepath }}
     </button>
   </div>

--- a/app/components/GlobItem.vue
+++ b/app/components/GlobItem.vue
@@ -79,17 +79,18 @@ const Noop = defineComponent({ setup: (_, { slots }) => () => slots.default?.() 
   <component :is="showsPopup ? VDropdown : Noop">
     <component
       :is="showsPopup ? 'button' : 'div'"
-      text-gray font-mono
+      data-a11y-skip
+      font-mono
       :class="active === true ? 'badge-active' : active === false ? 'badge op50' : 'badge'"
     >
       <template v-for="html, i of highlightedPatterns" :key="i">
-        <span v-if="i > 0" mx1 op50>&amp;</span>
+        <span v-if="i > 0" mx1 color-muted>&amp;</span>
         <span class="filter-hue-rotate-180" v-html="html" />
       </template>
     </component>
     <template #popper="{ shown, hide }">
       <div v-if="shown && popup === 'files'" max-h="30vh" min-w-80 of-auto p3>
-        <div v-if="isCompound" mb2 text-xs op60>
+        <div v-if="isCompound" mb2 text-xs color-muted>
           Compound glob (intersection of {{ patterns.length }} patterns)
         </div>
         <div v-if="files?.size" flex="~ col gap-1">
@@ -101,13 +102,13 @@ const Noop = defineComponent({ setup: (_, { slots }) => () => slots.default?.() 
             @click="hide()"
           />
         </div>
-        <div v-else text-center italic op50>
+        <div v-else text-center color-muted italic>
           No files matched this glob.
         </div>
       </div>
 
       <div v-if="shown && popup === 'configs'" max-h="30vh" min-w-80 of-auto p3>
-        <div v-if="isCompound" mb2 text-xs op60>
+        <div v-if="isCompound" mb2 text-xs color-muted>
           Compound glob (intersection of {{ patterns.length }} patterns)
         </div>
         <div v-if="configs?.length" flex="~ col gap-1">
@@ -121,7 +122,7 @@ const Noop = defineComponent({ setup: (_, { slots }) => () => slots.default?.() 
             </button>
           </div>
         </div>
-        <div v-else text-center italic op50>
+        <div v-else text-center color-muted italic>
           No configs matched this glob.
         </div>
       </div>

--- a/app/components/NavBar.vue
+++ b/app/components/NavBar.vue
@@ -27,17 +27,17 @@ function showDeprecated() {
 <template>
   <ConfigInspectorBadge text-3xl font-200 />
   <div v-if="payload.meta.configPath" flex="~ gap-1 items-center" my1 text-sm>
-    <span font-mono op35>{{ payload.meta.configPath }}</span>
+    <span color-muted font-mono>{{ payload.meta.configPath }}</span>
   </div>
   <div flex="~ gap-1 items-center wrap" text-sm>
-    <span op50>Composed with</span>
+    <span color-muted>Composed with</span>
     <span font-bold>{{ payload.configs.length }}</span>
-    <span op50>config items, updated</span>
-    <span op75>{{ lastUpdate }}</span>
+    <span color-muted>config items, updated</span>
+    <span color-muted>{{ lastUpdate }}</span>
     <div
       v-if="isFetching"
       flex="~ gap-2 items-center"
-      ml2 animate-pulse text-green
+      ml2 animate-pulse text-success-700 dark:text-success-300
     >
       <div i-svg-spinners-90-ring-with-bg flex-none text-sm />
       Fetching updates...
@@ -71,20 +71,20 @@ function showDeprecated() {
     </NuxtLink>
     <button
       title="Toggle Dark Mode"
-      i-ph-sun-dim-duotone dark:i-ph-moon-stars-duotone ml1 text-xl op50 hover:op75
+      i-ph-sun-dim-duotone dark:i-ph-moon-stars-duotone ml1 text-xl color-muted hover:color-base
       @click="toggleDark()"
     />
     <NuxtLink
       href="https://github.com/eslint/config-inspector" target="_blank"
-      i-carbon-logo-github text-lg op50 hover:op75
+      i-carbon-logo-github text-lg color-muted hover:color-base
     />
     <template v-if="deprecatedUsing.length">
       <div border="l base" ml3 mr2 h-5 w-1px />
       <button
         to="/configs"
-        border="~ orange/20 rounded-full"
+        border="~ warning-700/30 dark:warning-300/30 rounded-full"
         flex="~ gap-2 items-center"
-        bg-orange:5 px3 py1 text-sm text-orange hover:bg-orange:10
+        bg-warning-50 px3 py1 text-sm text-warning-700 dark:bg-warning-900:20 hover:bg-warning-100 dark:text-warning-300 dark:hover:bg-warning-900:30
         @click="showDeprecated"
       >
         <div i-ph-warning-duotone flex-none />

--- a/app/components/RuleDeprecatedInfo.vue
+++ b/app/components/RuleDeprecatedInfo.vue
@@ -38,7 +38,7 @@ const versionInfo = computed(() => {
 
 function getLinkClass(url: string | undefined) {
   return [
-    'text-blue5 dark:text-blue4',
+    'text-blue-700 dark:text-blue-300',
     url ? 'underline' : '',
   ]
 }
@@ -50,17 +50,17 @@ function getLinkClass(url: string | undefined) {
     :disabled="!deprecatedInfo"
   >
     <div
-      border="~ red/25 rounded"
-      select-none bg-red:5 px1 text-xs text-red
+      border="~ rose-700/30 dark:rose-300/30 rounded"
+      select-none bg-rose-50 px1 text-xs text-rose-700 dark:bg-rose-900:20 dark:text-rose-300
     >
       {{ invalid ? 'INVALID' : 'DEPRECATED' }}
     </div>
     <template #popper="{ shown }">
       <div
         v-if="shown && deprecatedInfo"
-        p-2 text-sm op75
+        p-2 text-sm color-base
       >
-        <p v-if="deprecatedInfo.message" mb1 flex="~ gap-1" text-red>
+        <p v-if="deprecatedInfo.message" mb1 flex="~ gap-1" text-rose-700 dark:text-rose-300>
           <span i-ph-warning-duotone inline-block />{{ deprecatedInfo.message }}
         </p>
         <p v-if="versionInfo">
@@ -92,7 +92,7 @@ function getLinkClass(url: string | undefined) {
           </template>
         </p>
         <p mt2>
-          <a text-red underline target="_blank" :href="deprecatedInfo.url">Learn more</a>
+          <a text-rose-700 underline dark:text-rose-300 target="_blank" :href="deprecatedInfo.url">Learn more</a>
         </p>
       </div>
     </template>

--- a/app/components/RuleItem.vue
+++ b/app/components/RuleItem.vue
@@ -125,8 +125,8 @@ function capitalize(str?: string) {
     <div
       :class="[
         rule.deprecated ? 'line-through' : '',
-        rule.invalid ? 'text-red' : '',
-        gridView ? 'op50 text-sm' : 'op75 ws-nowrap of-hidden text-ellipsis line-clamp-1',
+        rule.invalid ? 'text-red-700 dark:text-red-300' : '',
+        gridView ? 'color-muted text-sm' : 'color-muted ws-nowrap of-hidden text-ellipsis line-clamp-1',
       ]"
     >
       {{ rule.invalid ? 'Invalid rule has no description' : capitalize(rule.docs?.description) }}

--- a/app/components/RuleStateItem.vue
+++ b/app/components/RuleStateItem.vue
@@ -13,9 +13,9 @@ const props = defineProps<{
 }>()
 
 const colors = {
-  error: 'text-red',
-  warn: 'text-amber',
-  off: 'text-gray',
+  error: 'text-rose-700 dark:text-rose-300',
+  warn: 'text-warning-700 dark:text-warning-300',
+  off: 'color-muted',
 }
 
 const config = computed(() => payload.value.configs[props.state.configIndex]!)
@@ -44,22 +44,22 @@ function goto() {
         :level="state.level"
         :config-index="state.configIndex"
       />
-      <span v-if="state.level === 'off'" ml1 op50>Turned </span>
-      <span v-else ml1 op50>Set to </span>
+      <span v-if="state.level === 'off'" ml1 color-muted>Turned </span>
+      <span v-else ml1 color-muted>Set to </span>
       <span font-mono :class="colors[state.level]">{{ state.level }}</span>
       <template v-if="!isLocal">
-        <span op50>in</span>
-        <button hover="!color-base" text-gray @click="goto()">
+        <span color-muted>in</span>
+        <button hover="!color-base" color-muted @click="goto()">
           <ColorizedConfigName
             v-if="config.name" :name="config.name"
             px2 font-mono border="~ base rounded"
           />
-          <span op50> the </span>
+          <span color-muted> the </span>
           {{ nth(state.configIndex + 1) }}
-          <span op50> config item </span>
+          <span color-muted> config item </span>
         </button>
       </template>
-      <div v-else op50>
+      <div v-else color-muted>
         in this config
       </div>
     </div>
@@ -67,7 +67,7 @@ function goto() {
       <template v-if="config.files">
         <div i-ph-file-magnifying-glass-duotone my1 flex-none op75 />
         <div flex="~ col gap-2">
-          <div op50>
+          <div color-muted>
             Applies to files matching
           </div>
           <div flex="~ gap-2 items-center wrap">
@@ -77,14 +77,14 @@ function goto() {
       </template>
       <template v-else-if="config.rules">
         <div i-ph-files-duotone my1 flex-none op75 />
-        <div op50>
+        <div color-muted>
           Applied generally for all files
         </div>
       </template>
     </div>
     <template v-if="state.options?.length || defaultOptions?.length">
       <div items-center justify-between md:flex>
-        <div flex="~ gap-1" op50>
+        <div flex="~ gap-1" color-muted>
           <button
             v-if="state.options?.length"
             btn-action
@@ -125,7 +125,7 @@ function goto() {
       </template>
     </template>
     <template v-if="ruleOptions.viewType === 'state' && comparedOptions.hasRedundantOptions">
-      <div op50>
+      <div color-muted>
         Options <span italic op75>italicized</span> match the default for the rule
       </div>
     </template>

--- a/app/composables/color.ts
+++ b/app/composables/color.ts
@@ -50,8 +50,8 @@ export function getHsla(
   hue: number,
   opacity: number | string = 1,
 ) {
-  const saturation = isDark.value ? 50 : 65
-  const lightness = isDark.value ? 60 : 40
+  const saturation = isDark.value ? 55 : 70
+  const lightness = isDark.value ? 72 : 28
   return `hsla(${hue}, ${saturation}%, ${lightness}%, ${opacity})`
 }
 

--- a/app/pages/configs.vue
+++ b/app/pages/configs.vue
@@ -157,12 +157,12 @@ const HighlightMatch = defineComponent({
 
       for (const [from, to] of match.indices) {
         if (start < from)
-          array.push(h('span', { class: 'op50' }, content.slice(start, from)))
-        array.push(h('span', { class: 'text-purple font-bold' }, content.slice(from, to + 1)))
+          array.push(h('span', { class: 'color-muted' }, content.slice(start, from)))
+        array.push(h('span', { class: 'text-purple-700 dark:text-purple-300 font-bold' }, content.slice(from, to + 1)))
         start = to + 1
       }
       if (start < content.length)
-        array.push(h('span', { class: 'op50' }, content.slice(start)))
+        array.push(h('span', { class: 'color-muted' }, content.slice(start)))
       return array
     })
   },
@@ -217,7 +217,7 @@ onMounted(async () => {
           @keydown.up.prevent="autoCompleteMove(-1)"
           @keydown.enter.prevent="autoCompleteConfirm()"
         >
-        <div absolute bottom-0 left-0 top-0 flex="~ items-center justify-center" p4 op50>
+        <div absolute bottom-0 left-0 top-0 flex="~ items-center justify-center" p4 color-muted>
           <div i-ph-magnifying-glass-duotone />
         </div>
         <div
@@ -246,30 +246,31 @@ onMounted(async () => {
         <div v-if="filters.filepath">
           <div
             flex="~ gap-2 items-center wrap"
-            border="~ purple/20 rounded-full" bg-purple:10 px3 py1
+            border="~ purple-700/30 dark:purple-300/30 rounded-full"
+            bg-purple-50 px3 py1 dark:bg-purple-900:20
             :class="{ 'saturate-0': !filteredConfigs.length }"
           >
-            <div i-ph-file-dotted-duotone text-purple />
-            <span op50>Filepath</span>
+            <div i-ph-file-dotted-duotone text-purple-700 dark:text-purple-300 />
+            <span color-muted>Filepath</span>
             <code>{{ filters.filepath }}</code>
 
             <template v-if="!filteredConfigs.length">
-              <span op50>is not included or has been ignored</span>
+              <span color-muted>is not included or has been ignored</span>
             </template>
             <template v-else-if="stateStorage.viewFileMatchType === 'configs'">
-              <span op50>matched with</span>
+              <span color-muted>matched with</span>
               <span>{{ filteredConfigs.length }} / {{ payload.configs.length }}</span>
-              <span op50>config items</span>
+              <span color-muted>config items</span>
             </template>
             <template v-else>
-              <span op50>matched with total </span>
+              <span color-muted>matched with total </span>
               <span>{{ Object.keys(mergedRules.all).length }}</span>
-              <span op50>rules, </span>
+              <span color-muted>rules, </span>
               <span>{{ Object.keys(mergedRules.specific).length }}</span>
-              <span op50>of them are specific to the file</span>
+              <span color-muted>of them are specific to the file</span>
             </template>
             <button
-              i-ph-x text-sm op25 hover:op100
+              i-ph-x text-sm color-muted hover:color-base
               @click="filters.filepath = ''; input = ''"
             />
           </div>
@@ -277,14 +278,15 @@ onMounted(async () => {
         <div v-if="filters.rule">
           <div
             flex="~ gap-2 items-center"
-            border="~ blue/20 rounded-full" bg-blue:10 px3 py1
+            border="~ blue-700/30 dark:blue-300/30 rounded-full"
+            bg-blue-50 px3 py1 dark:bg-blue-900:20
           >
             <div i-ph-funnel-duotone />
-            <span op50>Filtered by</span>
+            <span color-muted>Filtered by</span>
             <ColorizedRuleName :name="filters.rule" />
-            <span op50>rule</span>
+            <span color-muted>rule</span>
             <button
-              i-ph-x text-sm op25 hover:op100
+              i-ph-x text-sm color-muted hover:color-base
               @click="filters.rule = ''"
             />
           </div>
@@ -294,7 +296,7 @@ onMounted(async () => {
         <template v-if="filters.filepath">
           <div border="~ base rounded" flex>
             <button
-              :class="stateStorage.viewFileMatchType === 'configs' ? 'btn-action-active' : 'op50'"
+              :class="stateStorage.viewFileMatchType === 'configs' ? 'btn-action-active' : ''"
               btn-action border-none
               @click="stateStorage.viewFileMatchType = stateStorage.viewFileMatchType === 'configs' ? 'merged' : 'configs'"
             >
@@ -303,7 +305,7 @@ onMounted(async () => {
             </button>
             <div border="l base" />
             <button
-              :class="stateStorage.viewFileMatchType !== 'configs' ? 'btn-action-active' : 'op50'"
+              :class="stateStorage.viewFileMatchType !== 'configs' ? 'btn-action-active' : ''"
               btn-action border-none
               @click="stateStorage.viewFileMatchType = stateStorage.viewFileMatchType === 'configs' ? 'merged' : 'configs'"
             >
@@ -322,7 +324,7 @@ onMounted(async () => {
             type="checkbox"
             @change="stateStorage.showSpecificOnly = !!($event.target as any).checked"
           >
-          <span op50>Show Specific Rules Only</span>
+          <span color-muted>Show Specific Rules Only</span>
         </label>
         <div flex-auto />
         <button
@@ -340,7 +342,7 @@ onMounted(async () => {
       </div>
 
       <template v-if="!filteredConfigs.length">
-        <div mt5 italic op50>
+        <div mt5 color-muted italic>
           No matched config items.
         </div>
         <template v-if="fileMatchResult?.globs.length">
@@ -360,7 +362,7 @@ onMounted(async () => {
         <template v-if="filters.filepath && stateStorage.viewFileMatchType === 'merged'">
           <details class="flat-config-item" border="~ base rounded-lg" relative>
             <summary block>
-              <div flex="~ gap-2 items-start" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono op75>
+              <div flex="~ gap-2 items-start" cursor-pointer select-none bg-hover px2 py2 text-sm color-base font-mono>
                 <div i-ph-caret-right class="[details[open]_&]:rotate-90" transition />
                 Merged Rules: Common to every file ({{ Object.keys(mergedRules.common).length }} rules)
               </div>
@@ -372,7 +374,7 @@ onMounted(async () => {
           </details>
           <details class="flat-config-item" border="~ base rounded-lg" open relative>
             <summary block>
-              <div flex="~ gap-2 items-start" cursor-pointer select-none bg-hover px2 py2 text-sm font-mono op75>
+              <div flex="~ gap-2 items-start" cursor-pointer select-none bg-hover px2 py2 text-sm color-base font-mono>
                 <div i-ph-caret-right class="[details[open]_&]:rotate-90" transition />
                 Merged Rules: Specific to matched file ({{ Object.keys(mergedRules.specific).length }} rules)
               </div>
@@ -383,7 +385,7 @@ onMounted(async () => {
               </div>
               <RuleList
                 m4
-                :get-bind="(name: string) => ({ class: 'op50' })"
+                :get-bind="(name: string) => ({ class: 'color-muted' })"
                 :rules="mergedRules.specificDisabled"
               />
             </template>

--- a/app/pages/files.vue
+++ b/app/pages/files.vue
@@ -13,14 +13,14 @@ function collapseAll() {
 
 <template>
   <div v-if="payload.filesResolved" flex="~ col gap-4" my4>
-    <div text-gray:75>
+    <div color-muted>
       This tab shows the preview for files match from the workspace.
-      This feature is <span text-amber>experimental</span> and may not be 100% accurate.
+      This feature is <span text-warning-700 dark:text-warning-300>experimental</span> and may not be 100% accurate.
     </div>
     <div flex="~ gap-2 items-center">
       <div border="~ base rounded" flex="~ inline">
         <button
-          :class="stateStorage.viewFilesTab === 'list' ? 'btn-action-active' : 'op50'"
+          :class="stateStorage.viewFilesTab === 'list' ? 'btn-action-active' : ''"
           btn-action border-none
           @click="stateStorage.viewFilesTab = 'list'"
         >
@@ -29,7 +29,7 @@ function collapseAll() {
         </button>
         <div border="l base" />
         <button
-          :class="stateStorage.viewFilesTab === 'group' ? 'btn-action-active' : 'op50'"
+          :class="stateStorage.viewFilesTab === 'group' ? 'btn-action-active' : ''"
           btn-action border-none
           @click="stateStorage.viewFilesTab = 'group' "
         >
@@ -74,7 +74,7 @@ function collapseAll() {
     </div>
   </div>
   <div v-else>
-    <div p3 italic op50>
+    <div p3 color-muted italic>
       No matched files found in the workspace.
     </div>
   </div>

--- a/app/pages/rules.vue
+++ b/app/pages/rules.vue
@@ -105,12 +105,12 @@ function resetFilters() {
           border="~ base rounded-full"
           w-full bg-transparent px3 py2 pl10 outline-none
         >
-        <div absolute bottom-0 left-0 top-0 flex="~ items-center justify-center" p4 op50>
+        <div absolute bottom-0 left-0 top-0 flex="~ items-center justify-center" p4 color-muted>
           <div i-ph-magnifying-glass-duotone />
         </div>
       </div>
       <div grid="~ cols-[max-content_1fr] gap-2" my2 items-center>
-        <div text-right text-sm op50>
+        <div text-right text-sm color-muted>
           Plugins
         </div>
         <OptionSelectGroup
@@ -125,7 +125,7 @@ function resetFilters() {
             } : {},
           }))]"
         />
-        <div text-right text-sm op50>
+        <div text-right text-sm color-muted>
           Usage
         </div>
         <OptionSelectGroup
@@ -144,7 +144,7 @@ function resetFilters() {
             </div>
           </template>
         </OptionSelectGroup>
-        <div text-right text-sm op50>
+        <div text-right text-sm color-muted>
           State
         </div>
         <OptionSelectGroup
@@ -154,9 +154,9 @@ function resetFilters() {
         >
           <template #default="{ value, title }">
             <div flex items-center gap-1>
-              <div v-if="value === 'recommended'" i-ph-check-square-duotone ml--0.5 text-green />
-              <div v-if="value === 'fixable'" i-ph-wrench-duotone ml--0.5 text-amber />
-              <div v-if="value === 'deprecated'" i-ph-prohibit-inset-duotone ml--1 text-gray />
+              <div v-if="value === 'recommended'" i-ph-check-square-duotone ml--0.5 text-green-700 dark:text-green-300 />
+              <div v-if="value === 'fixable'" i-ph-wrench-duotone ml--0.5 text-amber-700 dark:text-amber-300 />
+              <div v-if="value === 'deprecated'" i-ph-prohibit-inset-duotone ml--1 color-muted />
               {{ title || value }}
             </div>
           </template>
@@ -168,23 +168,24 @@ function resetFilters() {
       <div flex="~ gap-2" lt-sm:flex-col>
         <div
           flex="~ inline gap-2 items-center"
-          border="~ gray/20 rounded-full" bg-gray:10 px3 py1
+          border="~ gray/30 rounded-full" bg-gray:10 px3 py1
         >
           <div i-ph-list-checks-duotone />
           <span>{{ filtered.length }}</span>
-          <span op75>rules {{ isDefaultFilters ? 'enabled' : 'filtered' }}</span>
-          <span text-sm op50>out of {{ rules.length }} rules</span>
+          <span color-base>rules {{ isDefaultFilters ? 'enabled' : 'filtered' }}</span>
+          <span text-sm color-muted>out of {{ rules.length }} rules</span>
         </div>
         <button
           v-if="!isDefaultFilters"
           flex="~ inline gap-2 items-center self-start"
-          border="~ purple/20 rounded-full" bg-purple:10 px3 py1
+          border="~ purple-700/30 dark:purple-300/30 rounded-full"
+          bg-purple-50 px3 py1 dark:bg-purple-900:20
           @click="resetFilters()"
         >
-          <div i-ph-funnel-duotone text-purple />
-          <span op50>Clear Filter</span>
+          <div i-ph-funnel-duotone text-purple-700 dark:text-purple-300 />
+          <span color-muted>Clear Filter</span>
           <div
-            i-ph-x ml--1 text-sm op25 hover:op100
+            i-ph-x ml--1 text-sm color-muted hover:color-base
           />
         </button>
       </div>
@@ -211,7 +212,7 @@ function resetFilters() {
     <RuleList
       my4
       :rules="filtered"
-      :get-bind="(name: string) => ({ class: (payload.ruleToState.get(name)?.length || filters.state === 'unused') ? '' : 'op40' })"
+      :get-bind="(name: string) => ({ class: (payload.ruleToState.get(name)?.length || filters.state === 'unused') ? '' : 'color-muted' })"
     />
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
+    "@axe-core/playwright": "catalog:",
     "@eslint/config-array": "catalog:",
     "@iconify-json/carbon": "catalog:",
     "@iconify-json/file-icons": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@antfu/eslint-config':
       specifier: ^8.2.0
       version: 8.2.0
+    '@axe-core/playwright':
+      specifier: ^4.10.2
+      version: 4.11.3
     '@eslint/config-array':
       specifier: ^0.23.5
       version: 0.23.5
@@ -173,6 +176,9 @@ importers:
       '@antfu/eslint-config':
         specifier: 'catalog:'
         version: 8.2.0(@typescript-eslint/rule-tester@8.56.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@unocss/eslint-plugin@66.6.8(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.4)))
+      '@axe-core/playwright':
+        specifier: 'catalog:'
+        version: 4.11.3(playwright-core@1.59.1)
       '@eslint/config-array':
         specifier: 'catalog:'
         version: 0.23.5(patch_hash=9c56839266cb75a04e2a96a342456c69afd7549bf6c13a9ade49cc6d42de892a)
@@ -360,6 +366,11 @@ packages:
   '@apidevtools/json-schema-ref-parser@14.1.1':
     resolution: {integrity: sha512-uGF1YGOzzD50L7HLNWclXmsEhQflw8/zZHIz0/AzkJrKL5r9PceUipZxR/cp/8veTk4TVfdDJLyIwXLjaP5ePg==}
     engines: {node: '>= 20'}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2949,6 +2960,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -6488,6 +6503,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -9184,6 +9204,8 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
+
+  axe-core@4.11.4: {}
 
   b4a@1.6.7: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ patchedDependencies:
   '@eslint/config-array': patches/@eslint__config-array.patch
 catalog:
   '@antfu/eslint-config': ^8.2.0
+  '@axe-core/playwright': ^4.10.2
   '@eslint/config-array': ^0.23.5
   '@iconify-json/carbon': ^1.2.21
   '@iconify-json/file-icons': ^1.2.2

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -1,0 +1,58 @@
+import type { Page } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+import { gotoInspector } from './_helpers'
+
+type Mode = 'light' | 'dark'
+
+const MODES: Mode[] = ['light', 'dark']
+const PAGES = ['/configs', '/rules', '/files'] as const
+
+async function setMode(page: Page, mode: Mode): Promise<void> {
+  await page.addInitScript((m) => {
+    try {
+      localStorage.setItem('vueuse-color-scheme', m)
+    }
+    catch {}
+  }, mode)
+}
+
+async function scanContrast(page: Page) {
+  return new AxeBuilder({ page })
+    .withRules(['color-contrast'])
+    .exclude('.shiki')
+    .exclude('[data-a11y-skip]')
+    .analyze()
+}
+
+for (const mode of MODES) {
+  for (const path of PAGES) {
+    test(`a11y: ${path} has no color-contrast violations in ${mode} mode`, async ({ page }) => {
+      await setMode(page, mode)
+      await gotoInspector(page, path)
+
+      await expect.poll(async () => {
+        return page.evaluate(
+          m => document.documentElement.classList.contains('dark') === (m === 'dark'),
+          mode,
+        )
+      }).toBe(true)
+
+      const results = await scanContrast(page)
+      const message = JSON.stringify(
+        results.violations.map(v => ({
+          id: v.id,
+          impact: v.impact,
+          help: v.help,
+          nodes: v.nodes.map(n => ({
+            target: n.target,
+            failureSummary: n.failureSummary,
+          })),
+        })),
+        null,
+        2,
+      )
+      expect.soft(results.violations, message).toEqual([])
+    })
+  }
+}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -13,6 +13,8 @@ import {
 export default defineConfig({
   shortcuts: {
     'color-base': 'color-neutral-800 dark:color-neutral-300',
+    'color-muted': 'color-neutral-600 dark:color-neutral-400',
+    'color-faint': 'color-neutral-500 dark:color-neutral-500',
     'bg-base': 'bg-white dark:bg-neutral-900',
     'border-base': 'border-#aaa3',
 
@@ -21,16 +23,17 @@ export default defineConfig({
     'bg-code': 'bg-gray5:5',
     'bg-hover': 'bg-primary-400:5',
 
-    'color-active': 'color-primary-600 dark:color-primary-400',
-    'border-active': 'border-primary-600/25 dark:border-primary-400/25',
+    'color-active': 'color-primary-700 dark:color-primary-400',
+    'border-active': 'border-primary-700/30 dark:border-primary-400/25',
     'bg-active': 'bg-primary-400:10',
 
-    'btn-action': 'border border-base rounded flex gap-2 items-center px2 py1 op75 hover:op100 hover:bg-hover',
+    'btn-action': 'border border-base rounded flex gap-2 items-center px2 py1 color-muted hover:color-base hover:bg-hover',
     'btn-action-sm': 'btn-action text-sm',
-    'btn-action-active': 'color-active border-active! bg-active op100!',
+    'btn-action-active': 'color-active border-active! bg-active',
 
     'badge': 'border border-base rounded flex items-center px2',
-    'badge-active': 'badge border-amber:50 text-amber bg-amber:5',
+    'badge-active': 'badge border-amber-700:50 text-amber-700 bg-amber-50 dark:border-amber-300:50 dark:text-amber-300 dark:bg-amber-900:20',
+    'badge-muted': 'badge color-muted',
     'btn-badge': 'badge hover:bg-active',
   },
   theme: {


### PR DESCRIPTION
## Summary

- Add `@axe-core/playwright` and `tests/e2e/specs/a11y.spec.ts` running axe-core's `color-contrast` rule across `/configs`, `/rules`, `/files` in both light and dark mode.
- Replace ad-hoc `op35`/`op40`/`op50` text dimming (which compounded below WCAG-AA) with new semantic UnoCSS shortcuts `color-muted` / `color-faint`; bump light-mode `color-active` to `primary-700` so active nav links clear 4.5:1.
- Swap raw `text-orange` / `text-red` / `text-amber` / `text-purple` etc. for mode-specific darker shades, tighten plugin hue-hash lightness (40→28 light, 60→72 dark), and mark decorative `#index` watermarks and Shiki-rendered glob badges with `aria-hidden` / `data-a11y-skip` so axe ignores them.
- fix #137 

## Test plan

- [x] `pnpm test:e2e` — all 20 tests pass (5 pre-existing files + 6 new a11y cases)
- [x] `pnpm lint` clean
- [ ] Visual smoke in light + dark mode via `pnpm dev`