### PR TITLE
docs: add Yarn PnP usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Go to the project root that contains `eslint.config.js` and run:
 npx @eslint/config-inspector@latest
 ```
 
+If you are using [Yarn](https://yarnpkg.com/) with Plug'n'Play, `npx` may not resolve packages correctly. Instead, install it as a dev dependency and run:
+
+```bash
+yarn add -D @eslint/config-inspector
+yarn run config-inspector
+```
+
 Visit http://localhost:7777/ to view and play with your ESLint config. Changes to the config file will be updated automatically.
 
 Run `npx @eslint/config-inspector --help` to see all the CLI options available.


### PR DESCRIPTION
Add Yarn PnP usage instructions to the Usage section of README, as Yarn users in PnP mode cannot use `npx` to run the config inspector.

Closes #145

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
