### PR TITLE
fix: don't crash stats when a pass has no parse timing

### DIFF
--- a/src/rpc/run-stats.ts
+++ b/src/rpc/run-stats.ts
@@ -23,9 +23,9 @@ interface StatsLintResult {
     fixPasses: number
     times: {
       passes: {
-        parse: { total: number }
+        parse?: { total: number }
         rules?: Record<string, { total: number }>
-        fix: { total: number }
+        fix?: { total: number }
         total: number
       }[]
     }
@@ -178,8 +178,8 @@ export function aggregateStats(
 
     for (const pass of result.stats.times.passes) {
       file.total += pass.total
-      file.parse += pass.parse.total
-      file.fix += pass.fix.total
+      file.parse += pass.parse?.total ?? 0
+      file.fix += pass.fix?.total ?? 0
       for (const [name, { total }] of Object.entries(pass.rules ?? {})) {
         file.rules += total
         fileRuleTimes.set(name, (fileRuleTimes.get(name) ?? 0) + total)

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -91,4 +91,36 @@ describe('aggregateStats', () => {
     expect(report.files).toEqual([])
     expect(report.tasks).toEqual([])
   })
+
+  it('treats a pass with no parse or fix timings as zero', () => {
+    const report = aggregateStats([
+      {
+        filePath: '/repo/src/a.css',
+        errorCount: 0,
+        warningCount: 0,
+        stats: {
+          fixPasses: 0,
+          times: {
+            passes: [{
+              rules: { 'css/no-invalid-at-rules': { total: 3 } },
+              total: 5,
+            }],
+          },
+        },
+      },
+    ], '/repo', 10)
+
+    expect(report.totals.parse).toBe(0)
+    expect(report.totals.fix).toBe(0)
+    expect(report.totals.rules).toBe(3)
+    expect(report.totals.total).toBe(5)
+    expect(report.totals.other).toBe(2)
+    expect(report.files[0]).toMatchObject({
+      filepath: 'src/a.css',
+      parse: 0,
+      fix: 0,
+      rules: 3,
+      total: 5,
+    })
+  })
 })


### PR DESCRIPTION
Fixes #333.

`build --stats` threw when a pass had no parse bucket. Language plugins (CSS and friends) can emit that shape.

Missing parse and fix timings now count as 0, same as we already do for rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ESLint statistics now handle reports that omit parsing or fix timing data without errors.
  - Missing timing values are reported as zero, while other aggregated timing metrics remain accurate.

- **Tests**
  - Added coverage verifying correct totals and per-file statistics when parsing or fix timings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->